### PR TITLE
Adding status to number of nodes dashboard

### DIFF
--- a/templates/ocp-performance.jsonnet
+++ b/templates/ocp-performance.jsonnet
@@ -283,6 +283,11 @@ local nodeCount = genericGraphPanel('Number of nodes', 'none').addTarget(
     'sum(kube_node_info{})',
     legendFormat='Number of nodes',
   )
+).addTarget(
+  prometheus.target(
+    'sum(kube_node_status_condition{status="true"}) by (condition) > 0',
+    legendFormat='Node: {{ condition }}',
+  )
 );
 
 local nsCount = genericGraphPanel('Namespace count', 'none').addTarget(


### PR DESCRIPTION
Signed-off-by: Kedar Vijay Kulkarni <kkulkarni@redhat.com>

### Description
Looking at one of the dashboards perf team had put here [1] I saw we could add status to "Number of nodes" dashboard. It is useful.

### Fixes
Enhances jsonnet template to add that target. Tested with `make` and it rendered error-free.

[1]https://snapshot.raintank.io/dashboard/snapshot/y0xshWE8J42Fh1YaytIPheOT1nSLjRId?orgId=2&var-datasource=Cluster%20Prometheus&var-_worker_node=ip-10-0-111-23.us-west-2.compute.internal&var-_infra_node=ip-10-0-152-212.us-west-2.compute.internal&var-namespace=All&var-block_device=All&var-net_device=All&var-interval=2m


cc: @chaitanyaenr @jtaleric @mffiedler