### PR TITLE
Add benchmark keyword to list benchmark-operator namespace

### DIFF
--- a/templates/ocp-performance.jsonnet
+++ b/templates/ocp-performance.jsonnet
@@ -467,7 +467,7 @@ grafana.dashboard.new(
     '$datasource',
     'label_values(kube_pod_info, namespace)',
     '',
-    regex='/(openshift-.*|.*ripsaw.*|builder-.*|.*kube.*)/',
+    regex='/(openshift-.*|.*ripsaw.*|.*benchmark.*|builder-.*|.*kube.*)/',
     refresh=2,
   ) {
     label: 'Namespace',


### PR DESCRIPTION
### Description
Since benchmark-operator namespace now houses the perfscale stuff vs previously ripsaw, adding that filter for NS.
