### PR TITLE
secret key change in 4.10

### DIFF
--- a/dittybopper/deploy.sh
+++ b/dittybopper/deploy.sh
@@ -109,7 +109,7 @@ fi
 echo ""
 echo -e "\033[32mGetting environment vars...\033[0m"
 export PROMETHEUS_URL=$($k8s_cmd get secrets -n openshift-monitoring grafana-datasources -o go-template='{{index .data "prometheus.yaml" | base64decode }}' | jq '.datasources[0].url')
-export PROMETHEUS_PASSWORD=$($k8s_cmd get secrets -n openshift-monitoring grafana-datasources -o go-template='{{index .data "prometheus.yaml"| base64decode }}' | jq '.datasources[0].basicAuthPassword')
+export PROMETHEUS_PASSWORD=$($k8s_cmd get secrets -n openshift-monitoring grafana-datasources -o go-template='{{index .data "prometheus.yaml"| base64decode }}' | jq 'if .datasources[0].basicAuthPassword != null then .datasources[0].basicAuthPassword else .datasources[0].secureJsonData.basicAuthPassword end')
 echo "Prometheus URL is: ${PROMETHEUS_URL}"
 echo "Prometheus password collected."
 


### PR DESCRIPTION
### Description
Change in `grafana-datasources` secret in release 4.10, has `.datasources[0].secureJsonData.basicAuthPassword` instead of `.datasources[0].basicAuthPassword` 

4.7 got 
```
{
    "apiVersion": 1,
    "datasources": [
        {
            "access": "proxy",
            "basicAuth": true,
            "basicAuthPassword": "<secret>",
            "basicAuthUser": "internal",
            "editable": false,
            "jsonData": {
                "tlsSkipVerify": true
            },
            "name": "prometheus",
            "orgId": 1,
            "type": "prometheus",
            "url": "https://prometheus-k8s.openshift-monitoring.svc:9091",
            "version": 1
        }
    ]
}
```
4.10 got this,

```
{
    "apiVersion": 1,
    "datasources": [
        {
            "access": "proxy",
            "basicAuth": true,
            "secureJsonData": {
                "basicAuthPassword": "<secret>"
            },
            "basicAuthUser": "internal",
            "editable": false,
            "jsonData": {
                "tlsSkipVerify": true
            },
            "name": "prometheus",
            "orgId": 1,
            "type": "prometheus",
            "url": "https://prometheus-k8s.openshift-monitoring.svc:9091",
            "version": 1
        }
    ]
}
```

### Fixes
