### PR TITLE
changing `rate` to `irate` for container cpu metric

### DIFF
--- a/templates/ocp-performance.jsonnet
+++ b/templates/ocp-performance.jsonnet
@@ -195,14 +195,14 @@ local ovnKubeMasterMem = genericGraphLegendPanel('ovnkube-master Memory Usage', 
 
 local ovnKubeMasterCPU = genericGraphLegendPanel('ovnkube-master CPU Usage', 'percent').addTarget(
   prometheus.target(
-    'rate(container_cpu_usage_seconds_total{pod=~"ovnkube-master.*",namespace="openshift-ovn-kubernetes",container!~"POD|"}[$interval])*100',
+    'irate(container_cpu_usage_seconds_total{pod=~"ovnkube-master.*",namespace="openshift-ovn-kubernetes",container!~"POD|"}[$interval])*100',
     legendFormat='{{container}}-{{pod}}-{{node}}',
   )
 );
 
 local topOvnControllerCPU = genericGraphLegendPanel('Top 10 ovn-controller CPU Usage', 'percent').addTarget(
   prometheus.target(
-    'topk(10, rate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"}[$interval])*100)',
+    'topk(10, irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"}[$interval])*100)',
     legendFormat='{{node}}',
   )
 );


### PR DESCRIPTION
### Description
`irate` is more [precise](https://snapshots-origin.grafana.net/dashboard/snapshot/8dTBVRQdFM7gEDe1E4aMOogp7MAoeSR6?viewPanel=6&orgId=2) for cpu counter metrics than `rate` - https://prometheus.io/docs/prometheus/latest/querying/functions/#irate
[kube-burner](https://github.com/cloud-bulldozer/e2e-benchmarking/blob/master/workloads/kube-burner/metrics-profiles/metrics.yaml#L22) uses `irate` as well for container cpu usage.

### Fixes
