### PR TITLE
Disconnected support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,7 @@ $(ALLDIRS):
 format: deps
 	$(BINDIR)/jsonnetfmt -i $(TEMPLATES)
 
-build: deps $(TEMPLATESDIR)/grafonnet-lib offline-build
-
-offline-build: $(outputs)
+build: deps $(TEMPLATESDIR)/grafonnet-lib $(outputs)
 
 clean:
 	@echo "Cleaning up"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ $(ALLDIRS):
 format: deps
 	$(BINDIR)/jsonnetfmt -i $(TEMPLATES)
 
-build: deps $(TEMPLATESDIR)/grafonnet-lib $(outputs)
+build: deps $(TEMPLATESDIR)/grafonnet-lib offline-build
+
+offline-build: $(outputs)
 
 clean:
 	@echo "Cleaning up"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BINDIR = bin
 TEMPLATESDIR = templates
 OUTPUTDIR = rendered
 ALLDIRS = $(BINDIR) $(OUTPUTDIR)
+SYNCER_IMG_TAG = quay.io/cloud-bulldozer/dittybopper-syncer:latest
 
 # Get all templates at $(TEMPLATESDIR)
 TEMPLATES = $(wildcard $(TEMPLATESDIR)/*.jsonnet)
@@ -38,3 +39,8 @@ $(OUTPUTDIR)/%.json: $(TEMPLATESDIR)/%.jsonnet
 	@echo "Building template $<"
 	$(BINDIR)/jsonnet $< > $@
 
+build-syncer-image:
+	podman build -f dittybopper/syncer/Dockerfile -t=${SYNCER_IMG_TAG} .
+
+push-syncer-image:
+	podman push ${SYNCER_IMG_TAG}

--- a/dittybopper/README.md
+++ b/dittybopper/README.md
@@ -21,8 +21,6 @@ The `deploy.sh` script also requires `jq` to be installed on the system it is be
 
 ## Syncer Image and Deploying Forked Changes
 
-The image is built with the context at the root of the repository, and the image in the dittybopper/syncer directory.
-
 For disconnected support, the syncer image stores all dashboards on it. For deploying dittybopper with changed
 dashboards, you need to build it yourself from the root of the repository and update the SYNCER_IMAGE environment
 variable to match your own image repository.
@@ -30,6 +28,10 @@ variable to match your own image repository.
 If using disconnected, you need to sync the cloud-bulldozer grafana image (shown in the
 dittybopper/templates/dittybopper.yaml.template file) and your chosen syncer image
 (defaults to quay.io/cloud-bulldozer/dittybopper-syncer:latest).
+
+The syncer image is built with the context at the root of the repository, and the image in the dittybopper/syncer directory.
+You can build it with `make build-syncer-image SYNCER_IMG_TAG=container.registry.org/organization/syncer:latest`
+Alternatively, you can run the following command form the root folder of this repository: `podman build -f dittybopper/syncer/Dockerfile -t=container.registry.org/organization/syncer:latest .`
 
 ## Contribute
 

--- a/dittybopper/README.md
+++ b/dittybopper/README.md
@@ -19,6 +19,14 @@ templates will need adjustment accordingly.
 
 The `deploy.sh` script also requires `jq` to be installed on the system it is being run from.
 
+## Syncer Image and Deploying Forked Changes
+
+The image is built with the context at the root of the repository, and the image in the dittybopper/syncer directory.
+
+For disconnected support, the syncer image stores all dashboards on it. For deploying dittybopper with changed
+dashboards, you need to build it yourself from the root of the repository and update the SYNCER_IMAGE environment
+variable to match your own image repository.
+
 ## Contribute
 
 Pull requests are encouraged. If you find this tool useful, please help extend it for more use cases.

--- a/dittybopper/README.md
+++ b/dittybopper/README.md
@@ -27,6 +27,10 @@ For disconnected support, the syncer image stores all dashboards on it. For depl
 dashboards, you need to build it yourself from the root of the repository and update the SYNCER_IMAGE environment
 variable to match your own image repository.
 
+If using disconnected, you need to sync the cloud-bulldozer grafana image (shown in the
+dittybopper/templates/dittybopper.yaml.template file) and your chosen syncer image
+(defaults to quay.io/cloud-bulldozer/dittybopper-syncer:latest).
+
 ## Contribute
 
 Pull requests are encouraged. If you find this tool useful, please help extend it for more use cases.

--- a/dittybopper/deploy.sh
+++ b/dittybopper/deploy.sh
@@ -39,7 +39,7 @@ END
 export PROMETHEUS_USER=internal
 export GRAFANA_ADMIN_PASSWORD=admin
 export DASHBOARDS="ocp-performance.json api-performance-overview.json etcd-on-cluster-dashboard.json hypershift-performance.json ovn-dashboard.json"
-export REPOSITORY="https://github.com/cloud-bulldozer/performance-dashboards.git" # Repo to pull dashboards templates
+export SYNCER_IMAGE=${SYNCER_IMAGE:-"quay.io/cloud-bulldozer/dittybopper-syncer:latest"} # Syncer image
 
 # Set defaults for command options
 k8s_cmd='oc'

--- a/dittybopper/syncer/Dockerfile
+++ b/dittybopper/syncer/Dockerfile
@@ -3,6 +3,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 RUN microdnf install git make tar
 WORKDIR /dittybopper-syncer
 RUN chmod 775 /dittybopper-syncer
-COPY entrypoint.sh /bin/entrypoint.sh
-COPY ../.. /bin/dashboards
+COPY dittybopper/syncer/entrypoint.sh /bin/entrypoint.sh
+COPY . /dittybopper-syncer/dashboards
 ENTRYPOINT ["entrypoint.sh"]

--- a/dittybopper/syncer/Dockerfile
+++ b/dittybopper/syncer/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 RUN microdnf install git make tar
 WORKDIR /dittybopper-syncer
 COPY . /dittybopper-syncer/dashboards
-RUN chmod -R 775 /dittybopper-syncer
 COPY dittybopper/syncer/entrypoint.sh /bin/entrypoint.sh
 RUN make -C dashboards deps
+RUN chmod -R 775 /dittybopper-syncer
 ENTRYPOINT ["entrypoint.sh"]

--- a/dittybopper/syncer/Dockerfile
+++ b/dittybopper/syncer/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 RUN microdnf install git make tar
 WORKDIR /dittybopper-syncer
+COPY . /dittybopper-syncer/dashboards
 RUN chmod 775 /dittybopper-syncer
 COPY dittybopper/syncer/entrypoint.sh /bin/entrypoint.sh
-COPY . /dittybopper-syncer/dashboards
 ENTRYPOINT ["entrypoint.sh"]

--- a/dittybopper/syncer/Dockerfile
+++ b/dittybopper/syncer/Dockerfile
@@ -5,4 +5,5 @@ WORKDIR /dittybopper-syncer
 COPY . /dittybopper-syncer/dashboards
 RUN chmod -R 775 /dittybopper-syncer
 COPY dittybopper/syncer/entrypoint.sh /bin/entrypoint.sh
+RUN make -C dashboards deps
 ENTRYPOINT ["entrypoint.sh"]

--- a/dittybopper/syncer/Dockerfile
+++ b/dittybopper/syncer/Dockerfile
@@ -1,9 +1,12 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
+RUN microdnf install make git tar
+WORKDIR /performance-dashboards
+COPY . /performance-dashboards
+RUN make deps build
 
-RUN microdnf install git make tar
-WORKDIR /dittybopper-syncer
-COPY . /dittybopper-syncer/dashboards
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+WORKDIR /performance-dashboards
 COPY dittybopper/syncer/entrypoint.sh /bin/entrypoint.sh
-RUN make -C dashboards deps
-RUN chmod -R 775 /dittybopper-syncer
+COPY --from=builder /performance-dashboards /performance-dashboards
+RUN chmod -R 775 /performance-dashboards
 ENTRYPOINT ["entrypoint.sh"]

--- a/dittybopper/syncer/Dockerfile
+++ b/dittybopper/syncer/Dockerfile
@@ -9,5 +9,4 @@ WORKDIR /performance-dashboards
 COPY dittybopper/syncer/entrypoint.sh /bin/entrypoint.sh
 COPY --from=builder /performance-dashboards /performance-dashboards
 RUN chmod -R 775 /performance-dashboards
-RUN microdnf upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0
 ENTRYPOINT ["entrypoint.sh"]

--- a/dittybopper/syncer/Dockerfile
+++ b/dittybopper/syncer/Dockerfile
@@ -4,4 +4,5 @@ RUN microdnf install git make tar
 WORKDIR /dittybopper-syncer
 RUN chmod 775 /dittybopper-syncer
 COPY entrypoint.sh /bin/entrypoint.sh
+COPY ../.. /bin/dashboards
 ENTRYPOINT ["entrypoint.sh"]

--- a/dittybopper/syncer/Dockerfile
+++ b/dittybopper/syncer/Dockerfile
@@ -3,6 +3,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 RUN microdnf install git make tar
 WORKDIR /dittybopper-syncer
 COPY . /dittybopper-syncer/dashboards
-RUN chmod 775 /dittybopper-syncer
+RUN chmod -R 775 /dittybopper-syncer
 COPY dittybopper/syncer/entrypoint.sh /bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]

--- a/dittybopper/syncer/Dockerfile
+++ b/dittybopper/syncer/Dockerfile
@@ -2,11 +2,12 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
 RUN microdnf install make git tar
 WORKDIR /performance-dashboards
 COPY . /performance-dashboards
-RUN make deps build
+RUN make
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /performance-dashboards
 COPY dittybopper/syncer/entrypoint.sh /bin/entrypoint.sh
 COPY --from=builder /performance-dashboards /performance-dashboards
 RUN chmod -R 775 /performance-dashboards
+RUN microdnf upgrade --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0
 ENTRYPOINT ["entrypoint.sh"]

--- a/dittybopper/syncer/entrypoint.sh
+++ b/dittybopper/syncer/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-
-#git clone ${REPOSITORY} --depth=1 dashboards
 make -C dashboards build
 pushd dashboards/rendered
 while [[ $(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/api/health) != "200" ]]; do 

--- a/dittybopper/syncer/entrypoint.sh
+++ b/dittybopper/syncer/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-make -C dashboards build
+make -C dashboards offline-build
 pushd dashboards/rendered
 while [[ $(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/api/health) != "200" ]]; do 
   echo "Grafana still not ready, waiting 5 seconds"

--- a/dittybopper/syncer/entrypoint.sh
+++ b/dittybopper/syncer/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-make -C dashboards offline-build
-pushd dashboards/rendered
+pushd rendered
 while [[ $(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/api/health) != "200" ]]; do 
   echo "Grafana still not ready, waiting 5 seconds"
   sleep 5
@@ -17,7 +16,7 @@ for d in ${DASHBOARDS}; do
     echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" | \
       curl -Ss -XPOST -H "Content-Type: application/json" -H "Accept: application/json" -d@- \
       "http://admin:${GRAFANA_ADMIN_PASSWORD}@localhost:3000/api/dashboards/db" -o /dev/null
-  fi    
+  fi
 done
 
 echo "Dittybopper ready"

--- a/dittybopper/syncer/entrypoint.sh
+++ b/dittybopper/syncer/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-git clone ${REPOSITORY} --depth=1 dashboards
+#git clone ${REPOSITORY} --depth=1 dashboards
 make -C dashboards build
 pushd dashboards/rendered
 while [[ $(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/api/health) != "200" ]]; do 

--- a/dittybopper/templates/dittybopper.yaml.template
+++ b/dittybopper/templates/dittybopper.yaml.template
@@ -64,7 +64,7 @@ spec:
           value: ${GRAFANA_ADMIN_PASSWORD}
         - name: DASHBOARDS
           value: ${DASHBOARDS}
-        image: quay.io/jaredoconnell/dittybopper-syncer:disconnected-support
+        image: quay.io/joconnel/dittybopper-syncer:disconnected-support
       volumes:
       - name: sc-grafana-config
         configMap:

--- a/dittybopper/templates/dittybopper.yaml.template
+++ b/dittybopper/templates/dittybopper.yaml.template
@@ -64,7 +64,7 @@ spec:
           value: ${GRAFANA_ADMIN_PASSWORD}
         - name: DASHBOARDS
           value: ${DASHBOARDS}
-        image: quay.io/joconnel/dittybopper-syncer:disconnected-support
+        image: ${SYNCER_IMAGE}
       volumes:
       - name: sc-grafana-config
         configMap:

--- a/dittybopper/templates/dittybopper.yaml.template
+++ b/dittybopper/templates/dittybopper.yaml.template
@@ -64,9 +64,7 @@ spec:
           value: ${GRAFANA_ADMIN_PASSWORD}
         - name: DASHBOARDS
           value: ${DASHBOARDS}
-        - name: REPOSITORY
-          value: ${REPOSITORY}
-        image: quay.io/cloud-bulldozer/dittybopper-syncer:latest
+        image: quay.io/jaredoconnell/dittybopper-syncer:disconnected-support
       volumes:
       - name: sc-grafana-config
         configMap:

--- a/dittybopper/templates/k8s-dittybopper.yaml.template
+++ b/dittybopper/templates/k8s-dittybopper.yaml.template
@@ -52,9 +52,7 @@ spec:
           value: ${GRAFANA_ADMIN_PASSWORD}
         - name: DASHBOARDS
           value: ${DASHBOARDS}
-        - name: REPOSITORY
-          value: https://github.com/cloud-bulldozer/performance-dashboards.git
-        image: quay.io/cloud-bulldozer/dittybopper-syncer:latest
+        image: ${SYNCER_IMAGE}
       volumes:
       - name: sc-grafana-config
         configMap:


### PR DESCRIPTION
### Description
This PR successfully makes it so the dashboard templates are loaded into the syncer image, so that they can be deployed at runtime without cloning this repository.

The downside to this change is the syncer image needs to be updated for each PR, so that must be setup on quay.io