### PR TITLE
Action to load dashboard to grafana

### DIFF
--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -25,5 +25,5 @@ jobs:
         dashboard=$(cat ${t});
         echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" |
         curl -Ss -XPOST -H "Content-Type: application/json" -H "Accept: application/json" -d@-
-        "http://${{ secrets.GRAFANA_USER }}:${{ secrets.GRAFANA_PASSWORD }}@${{ secrets.AZURE_CREDENTIALS }}/api/dashboards/db" -o /dev/null;
+        "http://${{ secrets.GRAFANA_USER }}:${{ secrets.GRAFANA_PASSWORD }}@${{ secrets.GRAFANA_URL }}/api/dashboards/db" -o /dev/null;
 

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -3,9 +3,12 @@ defaults:
   run:
     shell: bash
 
+env:
+  DASHBOARDS: "[ 'rendered/kube-burner.json' ]"
+
 on:
   push:
-    branches: [ master ]
+    branches: [ master, auto-dashboard-load ]
 
 jobs:
   deploy:
@@ -21,8 +24,8 @@ jobs:
     # The secret GRAFANA_URL must be set with the format http://username:password@url.org without a trailing /
     - name: Import dashboards to grafana
       run: >
-        t=("rendered/kube-burner.json");
-        for path in ${t}; do
+        readarray -t dashboard_list < <(sed -n '/{/,/}/{s/[^:]*:[^"]*"\([^"]*\).*/\1/p;}' $DASHBOARDS);
+        for path in ${dashboard_list}; do
         echo "Importing ${path}";
         dashboard=$(cat ${path});
         echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" |

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -25,5 +25,5 @@ jobs:
         dashboard=$(cat ${t});
         echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" |
         curl -Ss -XPOST -H "Content-Type: application/json" -H "Accept: application/json" -d@- \
-        "http://${{ secrets.GRAFANA_URL }}/api/dashboards/db" -o /dev/null;
+        "${{ secrets.GRAFANA_URL }}/api/dashboards/db" -o /dev/null;
 

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -27,7 +27,7 @@ jobs:
       run: >
         dashboard_list=($(echo $DASHBOARDS | tr "," "\n"));
         for path in ${dashboard_list}; do
-        full_path="rendered/${path}"
+        full_path="rendered/${path}";
         echo "Importing ${full_path}";
         dashboard=$(cat ${full_path});
         echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" |

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Import dashboards to grafana
       run: >
         dashboard_list=($(echo $DASHBOARDS));
-        for path in ${dashboard_list}; do
+        for path in "${dashboard_list[@]}"; do
         full_path="rendered/${path}";
         echo "Importing ${full_path}";
         dashboard=$(cat ${full_path});

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -4,8 +4,8 @@ defaults:
     shell: bash
 
 env:
-  # Comma separated
-  DASHBOARDS: "kube-burner.json uperf-perf.json"
+  # Space separated list as a string of all dashboard json files in "rendered" to load
+  DASHBOARDS: "kube-burner.json"
 
 on:
   push:

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -18,6 +18,7 @@ jobs:
     - name: Compile dashboards
       run: make build
 
+    # The secret GRAFANA_URL must be set with the format http://username:password@url.org without a trailing /
     - name: Import dashboards to grafana
       run: >
         t="rendered/kube-burner.json";

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -5,7 +5,7 @@ defaults:
 
 on:
   push:
-    branches: [ master, auto-dashboard-load ]
+    branches: [ master ]
 
 jobs:
   deploy:

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -5,7 +5,7 @@ defaults:
 
 env:
   # Comma separated
-  DASHBOARDS: "rendered/kube-burner.json,test/dir"
+  DASHBOARDS: "kube-burner.json,uperf-perf.json"
 
 on:
   push:
@@ -27,6 +27,7 @@ jobs:
       run: >
         dashboard_list=($(echo $DASHBOARDS | tr "," "\n"));
         for path in ${dashboard_list}; do
+        path="rendered/${path}"
         echo "Importing ${path}";
         dashboard=$(cat ${path});
         echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" |

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Import dashboards to grafana
       run: >
-        t="rendered/kube-burner.json"
+        t="rendered/kube-burner.json";
         echo "Importing ${t}";
         dashboard=$(cat ${t});
         echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" |

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -1,0 +1,31 @@
+name: Grafana Syncer
+defaults:
+  run:
+    shell: bash
+
+on:
+  push:
+    branches: [ master, auto-dashboard-load ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Compile dashboards
+      run: make build
+
+    - name: Import dashboards to grafana
+      run: >
+	#for t in rendered/*.json; do
+        t="rendered/kube-burner.json"
+        echo "Importing ${t}";
+        dashboard=$(cat ${t});
+        echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" |
+        curl -Ss -XPOST -H "Content-Type: application/json" -H "Accept: application/json" -d@-
+        "http://${{ secrets.GRAFANA_USER }}:${{ secrets.GRAFANA_PASSWORD }}@${{ secrets.AZURE_CREDENTIALS }}/api/dashboards/db" -o /dev/null;
+        #done
+

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -4,7 +4,8 @@ defaults:
     shell: bash
 
 env:
-  DASHBOARDS: "rendered/kube-burner.json test/dir"
+  # Comma separated
+  DASHBOARDS: "rendered/kube-burner.json,test/dir"
 
 on:
   push:
@@ -24,7 +25,7 @@ jobs:
     # The secret GRAFANA_URL must be set with the format http://username:password@url.org without a trailing /
     - name: Import dashboards to grafana
       run: >
-        readarray -t dashboard_list < <(sed -n '/{/,/}/{s/[^:]*:[^"]*"\([^"]*\).*/\1/p;}' $DASHBOARDS);
+        dashboard_list=($(echo $DASHBOARDS | tr "," "\n"));
         for path in ${dashboard_list}; do
         echo "Importing ${path}";
         dashboard=$(cat ${path});

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -5,7 +5,7 @@ defaults:
 
 env:
   # Comma separated
-  DASHBOARDS: "kube-burner.json,uperf-perf.json"
+  DASHBOARDS: "kube-burner.json uperf-perf.json"
 
 on:
   push:
@@ -25,7 +25,7 @@ jobs:
     # The secret GRAFANA_URL must be set with the format http://username:password@url.org without a trailing /
     - name: Import dashboards to grafana
       run: >
-        dashboard_list=($(echo $DASHBOARDS | tr "," "\n"));
+        dashboard_list=($(echo $DASHBOARDS));
         for path in ${dashboard_list}; do
         full_path="rendered/${path}";
         echo "Importing ${full_path}";

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -20,12 +20,10 @@ jobs:
 
     - name: Import dashboards to grafana
       run: >
-	#for t in rendered/*.json; do
         t="rendered/kube-burner.json"
         echo "Importing ${t}";
         dashboard=$(cat ${t});
         echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" |
         curl -Ss -XPOST -H "Content-Type: application/json" -H "Accept: application/json" -d@-
         "http://${{ secrets.GRAFANA_USER }}:${{ secrets.GRAFANA_PASSWORD }}@${{ secrets.AZURE_CREDENTIALS }}/api/dashboards/db" -o /dev/null;
-        #done
 

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -27,9 +27,9 @@ jobs:
       run: >
         dashboard_list=($(echo $DASHBOARDS | tr "," "\n"));
         for path in ${dashboard_list}; do
-        path="rendered/${path}"
-        echo "Importing ${path}";
-        dashboard=$(cat ${path});
+        full_path="rendered/${path}"
+        echo "Importing ${full_path}";
+        dashboard=$(cat ${full_path});
         echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" |
         curl -Ss -XPOST -H "Content-Type: application/json" -H "Accept: application/json" -d@-
         "${{ secrets.GRAFANA_URL }}/api/dashboards/db" -o /dev/null;

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -4,7 +4,7 @@ defaults:
     shell: bash
 
 env:
-  DASHBOARDS: "[ 'rendered/kube-burner.json' ]"
+  DASHBOARDS: "rendered/kube-burner.json test/dir"
 
 on:
   push:

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -9,7 +9,7 @@ env:
 
 on:
   push:
-    branches: [ master, auto-dashboard-load ]
+    branches: [ master ]
 
 jobs:
   deploy:

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -24,6 +24,6 @@ jobs:
         echo "Importing ${t}";
         dashboard=$(cat ${t});
         echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" |
-        curl -Ss -XPOST -H "Content-Type: application/json" -H "Accept: application/json" -d@- \
+        curl -Ss -XPOST -H "Content-Type: application/json" -H "Accept: application/json" -d@-
         "${{ secrets.GRAFANA_URL }}/api/dashboards/db" -o /dev/null;
 

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -21,10 +21,12 @@ jobs:
     # The secret GRAFANA_URL must be set with the format http://username:password@url.org without a trailing /
     - name: Import dashboards to grafana
       run: >
-        t="rendered/kube-burner.json";
-        echo "Importing ${t}";
-        dashboard=$(cat ${t});
+        t=("rendered/kube-burner.json");
+        for path in ${t}; do
+        echo "Importing ${path}";
+        dashboard=$(cat ${path});
         echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" |
         curl -Ss -XPOST -H "Content-Type: application/json" -H "Accept: application/json" -d@-
         "${{ secrets.GRAFANA_URL }}/api/dashboards/db" -o /dev/null;
+        done
 

--- a/.github/workflows/syncer.yml
+++ b/.github/workflows/syncer.yml
@@ -24,6 +24,6 @@ jobs:
         echo "Importing ${t}";
         dashboard=$(cat ${t});
         echo "{\"dashboard\": ${dashboard}, \"overwrite\": true}" |
-        curl -Ss -XPOST -H "Content-Type: application/json" -H "Accept: application/json" -d@-
-        "http://${{ secrets.GRAFANA_USER }}:${{ secrets.GRAFANA_PASSWORD }}@${{ secrets.GRAFANA_URL }}/api/dashboards/db" -o /dev/null;
+        curl -Ss -XPOST -H "Content-Type: application/json" -H "Accept: application/json" -d@- \
+        "http://${{ secrets.GRAFANA_URL }}/api/dashboards/db" -o /dev/null;
 


### PR DESCRIPTION
### Description

This PR adds an action to load the kube burner dashboard to the internal grafana. The Grafana URL is stored in the secret GRAFANA_URL, with the format "http://user:pass@url.goes.here.org:port". The secret should be set before this PR is merged.
It is run on commits pushed to the master branch.

I tested this on my own grafana instance deployed with dittybopper on an aws openshift cluster.