### PR TITLE
Quay Image Build and Push

### DIFF
--- a/.github/workflows/grafana.yml
+++ b/.github/workflows/grafana.yml
@@ -1,4 +1,4 @@
-name: Grafana Syncer
+name: Grafana Importer
 defaults:
   run:
     shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ defaults:
 on:
   push:
     branches: [ master ]
-    tags:
-      - "*" # triggers only if push new tag version
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release syncer image
+defaults:
+  run:
+    shell: bash
+
+on:
+  push:
+    branches: [ master ]
+    tags:
+      - "*" # triggers only if push new tag version
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      ORG: cloud-bulldozer
+
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Login in quay
+      run: podman login quay.io -u ${QUAY_USER} -p ${QUAY_TOKEN}
+      env:
+        QUAY_USER: ${{ secrets.QUAY_USER }}
+        QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+
+    - name: Build syncer image
+      run: make build-syncer-image
+
+    - name: Push syncer image
+      run: make push-syncer-image
+
+
+
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
-    env:
-      ORG: cloud-bulldozer
-
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Description
The latest setup requires a new image for each change in the dashboards. This action is used to automatically build and push the image to the organization's quay.io.

For now it is limited to amd64 due to the use of an amd64 jsonnet binary download.