### PR TITLE
min of selected metrics in legend box

### DIFF
--- a/templates/ocp-performance.jsonnet
+++ b/templates/ocp-performance.jsonnet
@@ -20,6 +20,7 @@ local genericGraphLegendPanel(title, format) = grafana.graphPanel.new(
   legend_values=true,
   legend_alignAsTable=true,
   legend_max=true,
+  legend_min=true,
   legend_avg=true,
   legend_hideEmpty=true,
   legend_hideZero=true,


### PR DESCRIPTION
### Description
Including a `min` field in the legend table will be useful to find the least value of a duration.
For ex, to get the least `idle` cpu of a node or least `available` memory during a period.

### Fixes
