### PR TITLE
[Makefile/build-syncer-image] Remove the manifest if it already exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ $(OUTPUTDIR)/%.json: $(TEMPLATESDIR)/%.jsonnet
 	$(BINDIR)/jsonnet $< > $@
 
 build-syncer-image: build
+	! podman manifest exists ${SYNCER_IMG_TAG} || podman manifest rm ${SYNCER_IMG_TAG}
 	podman build --platform=${PLATFORM} -f dittybopper/syncer/Dockerfile --manifest=${SYNCER_IMG_TAG} .
 
 push-syncer-image:


### PR DESCRIPTION
### Description

Users could run `make build-syncer-image` multiple times between code changes, and the manifest list will get as many manifests as the times they build for each architecture, leading to images like https://quay.io/repository/aleskandrox/dittybopper-syncer/manifest/sha256:9def44babb5250f00a7bf4e047cf78064d3d708ed94edf3517fd329dcf8add41.

### Fixes

The changes in this PR are to delete an existing manifest in the local Podman registry, if any, before building it again.