### PR TITLE
Adding create token type and privileged namespace

### DIFF
--- a/dittybopper/deploy.sh
+++ b/dittybopper/deploy.sh
@@ -47,6 +47,7 @@ export GRAFANA_IMAGE=${GRAFANA_IMAGE:-"quay.io/cloud-bulldozer/grafana:7.3.4"} #
 # Set defaults for command options
 k8s_cmd='oc'
 namespace='dittybopper'
+namespace_file="./templates/dittybopper_ns.yaml.template"
 grafana_default_pass=True
 
 # Capture and act on command options
@@ -131,7 +132,7 @@ fi
 
 function namespace() {
   # Create namespace
-  $k8s_cmd "$1" namespace "$namespace"
+  $k8s_cmd "$1" -f "$namespace_file"
 }
 
 function grafana() {

--- a/dittybopper/deploy.sh
+++ b/dittybopper/deploy.sh
@@ -120,7 +120,7 @@ fi
 echo ""
 echo -e "\033[32mGetting environment vars...\033[0m"
 export PROMETHEUS_URL="https://$($k8s_cmd get routes -n openshift-monitoring prometheus-k8s -o jsonpath="{.spec.host}")"
-export PROMETHEUS_BEARER=$($k8s_cmd sa get-token -n openshift-monitoring prometheus-k8s || $k8s_cmd sa new-token -n openshift-monitoring prometheus-k8s)
+export PROMETHEUS_BEARER=$($k8s_cmd create token -n openshift-monitoring prometheus-k8s --duration=6h || $k8s_cmd sa get-token -n openshift-monitoring prometheus-k8s || $k8s_cmd sa new-token -n openshift-monitoring prometheus-k8s)
 echo "Prometheus URL is: ${PROMETHEUS_URL}"
 if [[ -n ${PROMETHEUS_BEARER} ]]; then
   echo "Prometheus bearer token collected."

--- a/dittybopper/templates/dittybopper_ns.yaml.template
+++ b/dittybopper/templates/dittybopper_ns.yaml.template
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: dittybopper
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: v1.24
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+  name: dittybopper


### PR DESCRIPTION
### Description
Needed to add a way to label the created namespace with privileges and change the way the prometheus token is obtained 

```
% ./deploy.sh


    ____  _ __  __        __
   / __ \(_) /_/ /___  __/ /_  ____  ____  ____  ___  _____
  / / / / / __/ __/ / / / __ \/ __ \/ __ \/ __ \/ _ \/ ___/
 / /_/ / / /_/ /_/ /_/ / /_/ / /_/ / /_/ / /_/ /  __/ /
/_____/_/\__/\__/\__, /_.___/\____/ .___/ .___/\___/_/
                /____/           /_/   /_/


Using k8s command: oc
Using namespace: dittybopper
Using default grafana password: admin

Getting environment vars...
Prometheus URL is: https://prometheus-k8s-openshift-monitoring.apps.**.qe.devcluster.openshift.com
Prometheus bearer token collected.

Creating namespace...
Looks like the namespace dittybopper already exists, deleting it
namespace "dittybopper" deleted
namespace/dittybopper created

Deploying Grafana...
service/dittybopper created
route.route.openshift.io/dittybopper created
deployment.apps/dittybopper created
configmap/sc-ocp-prom created
configmap/sc-grafana-config created

Waiting for dittybopper deployment to be available...
deployment.apps/dittybopper condition met

You can access the Grafana instance at http://dittybopper-dittybopper....
```


### Fixes
https://github.com/cloud-bulldozer/performance-dashboards/issues/59

```
12-07 08:01:30.782  Command "get-token" is deprecated, and will be removed in the future version. Use oc create token instead.
12-07 08:01:30.782  error: could not find a service account token for service account "prometheus-k8s"
12-07 08:01:31.074  Command "new-token" is deprecated, and will be removed in the future version. Use oc create token instead.
```