### PR TITLE
Simple fix to include other namespaces

### DIFF
--- a/templates/ocp-performance.jsonnet
+++ b/templates/ocp-performance.jsonnet
@@ -508,9 +508,9 @@ grafana.dashboard.new(
   grafana.template.new(
     'namespace',
     '$datasource',
-    'label_values(kube_pod_info, namespace)',
+    'label_values(kube_pod_info{namespace!="(cluster-density.*|node-density-.*)"}, namespace)',
     '',
-    regex='/(openshift-.*|.*ripsaw.*|.*benchmark.*|builder-.*|.*kube.*|stackrox)/',
+    regex='',
     refresh=2,
   ) {
     label: 'Namespace',


### PR DESCRIPTION
This fix will remove the regex, and simply ignore the kube-burner generated namespaces for cluster-density and node-density.

Signed-off-by: Joe Talerico <jtaleric@redhat.com>