### PR TITLE
Remove prometheus token duration

### DIFF
--- a/dittybopper/deploy.sh
+++ b/dittybopper/deploy.sh
@@ -121,7 +121,7 @@ fi
 echo ""
 echo -e "\033[32mGetting environment vars...\033[0m"
 export PROMETHEUS_URL="https://$($k8s_cmd get routes -n openshift-monitoring prometheus-k8s -o jsonpath="{.spec.host}")"
-export PROMETHEUS_BEARER=$($k8s_cmd create token -n openshift-monitoring prometheus-k8s --duration=6h || $k8s_cmd sa get-token -n openshift-monitoring prometheus-k8s || $k8s_cmd sa new-token -n openshift-monitoring prometheus-k8s)
+export PROMETHEUS_BEARER=$($k8s_cmd create token -n openshift-monitoring prometheus-k8s || $k8s_cmd sa get-token -n openshift-monitoring prometheus-k8s || $k8s_cmd sa new-token -n openshift-monitoring prometheus-k8s)
 echo "Prometheus URL is: ${PROMETHEUS_URL}"
 if [[ -n ${PROMETHEUS_BEARER} ]]; then
   echo "Prometheus bearer token collected."


### PR DESCRIPTION
### Description
If a cluster is up for longer than 6h, the token needs to be refreshed.

I see the expiration as unnecessary maintenance overhead.
