### PR TITLE
Added node ready latency metric and used corrected formatting

### DIFF
--- a/templates/ovn-dashboard.jsonnet
+++ b/templates/ovn-dashboard.jsonnet
@@ -135,7 +135,7 @@ local sync_latency = genericGraphLegendPanel('Sync Service Latency', 's').addTar
 local ovnkube_node_ready_latency = genericGraphLegendPanel('OVNKube Node Ready Latency', 's').addTarget(
   prometheus.target(
     'ovnkube_node_ready_duration_seconds{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container!~"POD|"}',
-    legendFormat='{{pod}} - Time taken to get to ready state',
+    legendFormat='{{pod}}',
   )
 );
 

--- a/templates/ovn-dashboard.jsonnet
+++ b/templates/ovn-dashboard.jsonnet
@@ -132,6 +132,13 @@ local sync_latency = genericGraphLegendPanel('Sync Service Latency', 's').addTar
   )
 );
 
+local ovnkube_node_ready_latency = genericGraphLegendPanel('OVNKube Node Ready Latency', 's').addTarget(
+  prometheus.target(
+    'ovnkube_node_ready_duration_seconds{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container!~"POD|"}',
+    legendFormat='{{pod}} - Time taken to get to ready state',
+  )
+);
+
 local work_queue = genericGraphLegendPanel('OVNKube Master workqueue', 'short').addTarget(
   prometheus.target(
     'rate(ovnkube_master_workqueue_adds_total[1m])',
@@ -180,7 +187,7 @@ local ovnCNIDel = genericGraphLegendPanel('CNI Request DEL Latency', 's').addTar
   )
 );
 
-local ovnLatencyCalculate = genericGraphLegendPanel('Duration for OVN to apply network configuration','s').addTarget(
+local ovnLatencyCalculate = genericGraphLegendPanel('Duration for OVN to apply network configuration', 's').addTarget(
   prometheus.target(
     'histogram_quantile(0.99, sum(rate(ovnkube_master_network_programming_duration_seconds_bucket[2m])) by (pod, le))',
     legendFormat='{{pod}} - Kind Pod',
@@ -295,6 +302,7 @@ grafana.dashboard.new(
       pod_latency { gridPos: { x: 0, y: 8, w: 24, h: 10 } },
       sync_latency { gridPos: { x: 0, y: 16, w: 24, h: 10 } },
       ovnLatencyCalculate { gridPos: { x: 0, y: 24, w: 24, h: 10 } },
+      ovnkube_node_ready_latency { gridPos: { x: 0, y: 32, w: 24, h: 10 } },
     ]
   ), { gridPos: { x: 0, y: 0, w: 24, h: 1 } }
 )


### PR DESCRIPTION
### Description
This PR adds a new metric, to understand duration for OVN node to get to a ready state.

### Metric Screenshots

![Screenshot from 2023-02-06 21-44-47](https://user-images.githubusercontent.com/28471457/217136357-38fe8682-6c5a-4714-ba64-3bfbc53325b7.png)

![Screenshot from 2023-02-06 21-44-53](https://user-images.githubusercontent.com/28471457/217136369-0cc0ebe0-d003-4a0b-a6bf-23df1fa0b497.png)

![Screenshot from 2023-02-06 21-44-57](https://user-images.githubusercontent.com/28471457/217136381-7f029579-61fe-4047-888d-b49ece632c6e.png)