### PR TITLE
Adapt hypershift dashboard to management clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINDIR = bin
 TEMPLATESDIR = templates
 OUTPUTDIR = rendered
 ALLDIRS = $(BINDIR) $(OUTPUTDIR)
-SYNCER_IMG_TAG = quay.io/cloud-bulldozer/dittybopper-syncer:latest
+SYNCER_IMG_TAG ?= quay.io/cloud-bulldozer/dittybopper-syncer:latest
 PLATFORM = linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 
 # Get all templates at $(TEMPLATESDIR)

--- a/dittybopper/deploy.sh
+++ b/dittybopper/deploy.sh
@@ -130,6 +130,13 @@ else
   exit 1
 fi
 
+#Identify Hypershift Management Cluster
+if [ $($k8s_cmd get crd hostedclusters.hypershift.openshift.io 2>/dev/null | wc -l) -ne 0 ] ; then
+  echo "Detected Hypershift Management Cluster"
+  export HYPERSHIFT_MANAGEMENT_CLUSTER="yes"
+  export OBO_URL="http://hypershift-monitoring-stack-prometheus.openshift-observability-operator.svc.cluster.local:9090"
+fi
+
 function namespace() {
   # Create namespace
   $k8s_cmd "$1" -f "$namespace_file"

--- a/dittybopper/templates/dittybopper.yaml.template
+++ b/dittybopper/templates/dittybopper.yaml.template
@@ -20,7 +20,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: dittybopper
-namespace: $namespace
+  namespace: $namespace
 spec:
   to:
     name: dittybopper
@@ -33,7 +33,7 @@ metadata:
   labels:
     app: dittybopper
   name: dittybopper
-namespace: $namespace
+  namespace: $namespace
 spec:
   replicas: 1
   selector:
@@ -77,7 +77,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: sc-ocp-prom
-namespace: $namespace
+  namespace: $namespace
 data:
   ocp-prometheus.yml: |
     apiVersion: 1
@@ -97,12 +97,19 @@ data:
           Bearer ${PROMETHEUS_BEARER}
       version: 1
       editable: false
+    - name: OBO
+      type: prometheus
+      access: proxy
+      orgId: 1
+      url: ${OBO_URL}
+      version: 1
+      editable: false
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: sc-grafana-config
-namespace: $namespace
+  namespace: $namespace
 data:
   grafana.ini: |
     ##################### Grafana Configuration Example #####################

--- a/templates/ocp-performance.jsonnet
+++ b/templates/ocp-performance.jsonnet
@@ -462,6 +462,7 @@ grafana.dashboard.new(
     'datasource',
     'prometheus',
     '',
+    regex='/^Cluster Prometheus$/',
   )
 )
 


### PR DESCRIPTION
- Add OBO endpoint
- Modify regexp on hypershift dashboard to correct namespace names
- Fix some graphs on hypershift dashboards, pointing to incorrect namespaces
- On hypershift dashboard, using Prometheus Endpoint for Management Metrics and OBO for Hypershift ones
-  Add graphs for CPU and Mem for OBO and hypershift on the management side, and top10 CPU & Mem on Hosted Clusters Control Plane
- Correct indentation of namespace parameter on ocp objects causing `Warning: unknown field "namespace"`
