### PR TITLE
increase token expire time

### DIFF
--- a/dittybopper/deploy.sh
+++ b/dittybopper/deploy.sh
@@ -121,7 +121,7 @@ fi
 echo ""
 echo -e "\033[32mGetting environment vars...\033[0m"
 export PROMETHEUS_URL="https://$($k8s_cmd get routes -n openshift-monitoring prometheus-k8s -o jsonpath="{.spec.host}")"
-export PROMETHEUS_BEARER=$($k8s_cmd create token -n openshift-monitoring prometheus-k8s || $k8s_cmd sa get-token -n openshift-monitoring prometheus-k8s || $k8s_cmd sa new-token -n openshift-monitoring prometheus-k8s)
+export PROMETHEUS_BEARER=$($k8s_cmd create token -n openshift-monitoring prometheus-k8s --duration 240h || $k8s_cmd sa get-token -n openshift-monitoring prometheus-k8s || $k8s_cmd sa new-token -n openshift-monitoring prometheus-k8s)
 echo "Prometheus URL is: ${PROMETHEUS_URL}"
 if [[ -n ${PROMETHEUS_BEARER} ]]; then
   echo "Prometheus bearer token collected."


### PR DESCRIPTION
### Description
1 hour after deploying dittybopper, the dashboards can not be displayed because of 'Forbidden'. Checked the token created by deploy.sh, it was already expired. Redeploy can fix the issue but it will come back again 1 hour later.

Create a  new token with `oc create token`, check the exp time, it's 1 hour after creation.
   iat: 1677053861 2/22/2023, 1:47:41 PM
   nbf: 1677053861 2/22/2023, 1:47:41 PM
   exp: 1677057461 2/22/2023, 2:47:41 PM

### Fixes
Increase token expire time to 240h to avoid token expire during test.

