### PR TITLE
Bump grafana version to 9.4.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       run: make build
 
     - name: Run grafana container
-      run: sudo docker run -d -p 3000:3000 docker.io/grafana/grafana:7.1.2
+      run: sudo docker run -d -p 3000:3000 docker.io/grafana/grafana:9.4.3
 
     - name: Wait for grafana
       run: while [[ $(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/api/health) != "200" ]]; do  sleep 1; done

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-JSONNET = https://github.com/google/jsonnet/releases/download/v0.15.0/jsonnet-bin-v0.15.0-linux.tar.gz
+JSONNET = https://github.com/google/jsonnet/releases/download/v0.17.0/jsonnet-bin-v0.17.0-linux.tar.gz
 BINDIR = bin
 TEMPLATESDIR = templates
 OUTPUTDIR = rendered

--- a/dittybopper/deploy.sh
+++ b/dittybopper/deploy.sh
@@ -42,7 +42,7 @@ export PROMETHEUS_USER=internal
 export GRAFANA_ADMIN_PASSWORD=admin
 export DASHBOARDS="ocp-performance.json api-performance-overview.json etcd-on-cluster-dashboard.json hypershift-performance.json ovn-dashboard.json"
 export SYNCER_IMAGE=${SYNCER_IMAGE:-"quay.io/cloud-bulldozer/dittybopper-syncer:latest"} # Syncer image
-export GRAFANA_IMAGE=${GRAFANA_IMAGE:-"quay.io/cloud-bulldozer/grafana:7.3.4"} # Syncer image
+export GRAFANA_IMAGE=${GRAFANA_IMAGE:-"quay.io/cloud-bulldozer/grafana:9.4.3"} # Syncer image
 
 # Set defaults for command options
 k8s_cmd='oc'

--- a/dittybopper/k8s-deploy.sh
+++ b/dittybopper/k8s-deploy.sh
@@ -40,7 +40,7 @@ export PROMETHEUS_USER=internal
 export GRAFANA_ADMIN_PASSWORD=admin
 export DASHBOARDS="k8s-performance.json"
 export SYNCER_IMAGE=${SYNCER_IMAGE:-"quay.io/cloud-bulldozer/dittybopper-syncer:latest"} # Syncer image
-export GRAFANA_IMAGE=${GRAFANA_IMAGE:-"quay.io/cloud-bulldozer/grafana:7.3.4"} # Syncer image
+export GRAFANA_IMAGE=${GRAFANA_IMAGE:-"quay.io/cloud-bulldozer/grafana:9.4.3"} # Syncer image
 
 
 # Set defaults for command options


### PR DESCRIPTION

- Updated grafana container version to 9.4.3
- Updated jsonnet to latest version with binary for linux

This new version can be verified here: 

http://dittybopper-dittybopper.apps.mrnd-gr.bcgo.s1.devshift.org/?orgId=1

