### PR TITLE
Edited deploy script so deploy_template default wouldn't be relative …

### DIFF
--- a/dittybopper/deploy.sh
+++ b/dittybopper/deploy.sh
@@ -93,7 +93,7 @@ done
 if [[ ! -z ${template} ]]; then
   deploy_template=${template}
 else
-  deploy_template="templates/dittybopper.yaml.template"
+  deploy_template="$(dirname $(realpath ${BASH_SOURCE[0]}))/templates/dittybopper.yaml.template"
 fi
 
 


### PR DESCRIPTION
…path

### Description
Previously, `deploy.sh` wouldn't path to the default Dittybopper template if the script wasn't run in the same directory - this PR allows the script to be run from anywhere

Tested this here: https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/nweinber-e2e-benchmarking-multibranch-pipeline/job/netobserv-perf-tests/93/

### Fixes
`deploy.sh`