### PR TITLE
sortDesc on all panels

### DIFF
--- a/templates/ocp-performance.jsonnet
+++ b/templates/ocp-performance.jsonnet
@@ -25,6 +25,7 @@ local genericGraphLegendPanel(title, format) = grafana.graphPanel.new(
   legend_hideEmpty=true,
   legend_hideZero=true,
   legend_sort='max',
+  legend_sortDesc='true',
   nullPointMode='null as zero',
   sort='decreasing',
 );


### PR DESCRIPTION
Fixes #54

## Type of change

- [X] Bug fix

## Description

Grafana panels sort ascending by default.

This is terrible default behavior, requiring countless, pointless clicks, and this can be simply fixed with sortDesc!

## Related Tickets & Documents

- Closes #54

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] If it is a core feature, I have added thorough tests.