### PR TITLE
add container_memory_rss system.slice

### DIFF
--- a/templates/General/ocp-performance.jsonnet
+++ b/templates/General/ocp-performance.jsonnet
@@ -400,6 +400,13 @@ local top10ContMem = genericGraphLegendPanel('Top 10 container RSS', 'bytes').ad
   )
 );
 
+local contMemRSSSystemSlice = genericGraphLegendPanel('container RSS system.slice', 'bytes').addTarget(
+  prometheus.target(
+    'sum by (node)(container_memory_rss{id="/system.slice"})',
+    legendFormat='system.slice - {{ node }}',
+  )
+);
+
 local podDistribution = genericGraphLegendPanel('Pod Distribution', 'none').addTarget(
   prometheus.target(
     'count(kube_pod_info{}) by (node)',
@@ -641,7 +648,8 @@ grafana.dashboard.new(
     routesCount { gridPos: { x: 0, y: 20, w: 8, h: 8 } },
     alerts { gridPos: { x: 8, y: 20, w: 8, h: 8 } },
     podDistribution { gridPos: { x: 16, y: 20, w: 8, h: 8 } },
-    top10ContMem { gridPos: { x: 0, y: 28, w: 24, h: 8 } },
+    top10ContMem { gridPos: { x: 0, y: 28, w: 12, h: 8 } },
+    contMemRSSSystemSlice { gridPos: { x: 12, y: 28, w: 12, h: 8 } },
     top10ContCPU { gridPos: { x: 0, y: 36, w: 12, h: 8 } },
     goroutines_count { gridPos: { x: 12, y: 36, w: 12, h: 8 } },
   ]


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In bug https://bugzilla.redhat.com/show_bug.cgi?id=1951877 
Memory consumption keeps growing day by day for "/system.slice" (only on Master nodes)
In 2 days graph it shoot to more than 1G of memory consumption from 500MB aprox.

This pr adds a new Metrics to monitor this metrics:
"sum by(node) (container_memory_rss{id="/system.slice"})"
## Related Tickets & Documents
https://issues.redhat.com/browse/OCPQE-17527

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
