### PR TITLE
Adding debugs when dittybopper deployment fails

### DIFF
--- a/dittybopper/deploy.sh
+++ b/dittybopper/deploy.sh
@@ -147,7 +147,14 @@ function grafana() {
   if [[ ! $delete ]]; then
     echo ""
     echo -e "\033[32mWaiting for dittybopper deployment to be available...\033[0m"
-    $k8s_cmd wait --for=condition=available -n $namespace deployment/dittybopper --timeout=60s
+    if $k8s_cmd wait --for=condition=available -n $namespace deployment/dittybopper --timeout=60s; then
+      exit 0
+    else
+      $k8s_cmd get pods -n $namespace
+      $k8s_cmd get deploy -n $namespace
+      $k8s_cmd logs -l app=dittybopper --max-log-requests=100 -n $namespace --all-containers=true
+      exit 1
+    fi
   fi
 }
 


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Added some debugs to check the dittybopper deployment status and containers logs for easy debugging.

## Related Tickets & Documents
https://redhat-internal.slack.com/archives/C020CKMP6CT/p1698249942353429

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested in local by setting a smaller timeout
```
Waiting for dittybopper deployment to be available...
error: timed out waiting for the condition on deployments/dittybopper
NAME                          READY   STATUS              RESTARTS   AGE
dittybopper-5d7cf58cf-cbb8t   0/2     ContainerCreating   0          3s
NAME          READY   UP-TO-DATE   AVAILABLE   AGE
dittybopper   0/1     1            0           3s
Error from server (BadRequest): container "dittybopper-syncer" in pod "dittybopper-5d7cf58cf-cbb8t" is waiting to start: ContainerCreating
```
