### PR TITLE
Migrating dashboards to v2 Version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
 
     - name: Build & push syncer image
-      run: make build-syncer-image v2 push-syncer-image
+      run: make v2 build-syncer-image push-syncer-image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
 
     - name: Build & push syncer image
-      run: make build-syncer-image push-syncer-image
+      run: make build-syncer-image v2 push-syncer-image

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ $(OUTPUTDIR)/%.json: $(TEMPLATESDIR)/%.jsonnet
 v2: all
 	@echo "Rendered the v2 dashboards with latest grafonnet library"
 
-build-syncer-image: build
+build-syncer-image: v2
 	podman build --platform=${PLATFORM} -f Dockerfile --manifest=${SYNCER_IMG_TAG} .
 
 push-syncer-image:


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->
Migrating dashboards to v2 Version
## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
 - [x] v2 dashboards 
 ``` bash 
[smanda performance-dashboards]$  make build-syncer-image v2 push-syncer-image
mkdir -p bin rendered
Downloading jsonnet binary
curl -s -L https://github.com/google/go-jsonnet/releases/download/v0.20.0/go-jsonnet_0.20.0_Linux_x86_64.tar.gz | tar xz -C bin
Downloading jb binary
curl -s -L https://github.com/jsonnet-bundler/jsonnet-bundler/releases/latest/download/jb-linux-amd64 -o bin/jb
chmod +x bin/jb
Downloading vendor files
cd templates && ../bin/jb install && cd ../
GET https://github.com/grafana/grafonnet/archive/9e217263ac4b922ca2e00bc5cc36ada2311bb5a6.tar.gz 200
GET https://github.com/grafana/grafonnet/archive/9e217263ac4b922ca2e00bc5cc36ada2311bb5a6.tar.gz 200
GET https://github.com/jsonnet-libs/docsonnet/archive/503e5c8fe96d6b55775037713ac10b184709ad93.tar.gz 200
GET https://github.com/jsonnet-libs/xtd/archive/c1a315a7dbead0335a5e0486acc5583395b22a24.tar.gz 200
bin/jsonnetfmt -i templates/CPT/ingress-perf-v2.jsonnet templates/CPT/k8s-netperf-v2.jsonnet templates/CPT/kube-burner-report-ocp-wrapper-v2.jsonnet templates/General/api-performance-overview-v2.jsonnet templates/General/cilium-k8s-perf-v2.jsonnet templates/General/etcd-on-cluster-dashboard-v2.jsonnet templates/General/hypershift-performance-v2.jsonnet templates/General/k8s-perf-v2.jsonnet templates/General/kube-burner-v2.jsonnet templates/General/ocp-performance-v2.jsonnet templates/General/ovn-monitoring-v2.jsonnet templates/General/pgbench-dashboard-v2.jsonnet templates/General/uperf-v2.jsonnet templates/General/vegeta-wrapper-v2.jsonnet templates/General/ycsb-v2.jsonnet
Building template templates/CPT/ingress-perf-v2.jsonnet
mkdir -p rendered/CPT/
bin/jsonnet -J ./templates/vendor templates/CPT/ingress-perf-v2.jsonnet > rendered/CPT/ingress-perf-v2.json
Building template templates/CPT/k8s-netperf-v2.jsonnet
mkdir -p rendered/CPT/
bin/jsonnet -J ./templates/vendor templates/CPT/k8s-netperf-v2.jsonnet > rendered/CPT/k8s-netperf-v2.json
Building template templates/CPT/kube-burner-report-ocp-wrapper-v2.jsonnet
mkdir -p rendered/CPT/
bin/jsonnet -J ./templates/vendor templates/CPT/kube-burner-report-ocp-wrapper-v2.jsonnet > rendered/CPT/kube-burner-report-ocp-wrapper-v2.json
Building template templates/General/api-performance-overview-v2.jsonnet
mkdir -p rendered/General/
bin/jsonnet -J ./templates/vendor templates/General/api-performance-overview-v2.jsonnet > rendered/General/api-performance-overview-v2.json
Building template templates/General/cilium-k8s-perf-v2.jsonnet
mkdir -p rendered/General/
bin/jsonnet -J ./templates/vendor templates/General/cilium-k8s-perf-v2.jsonnet > rendered/General/cilium-k8s-perf-v2.json
Building template templates/General/etcd-on-cluster-dashboard-v2.jsonnet
mkdir -p rendered/General/
bin/jsonnet -J ./templates/vendor templates/General/etcd-on-cluster-dashboard-v2.jsonnet > rendered/General/etcd-on-cluster-dashboard-v2.json
Building template templates/General/hypershift-performance-v2.jsonnet
mkdir -p rendered/General/
bin/jsonnet -J ./templates/vendor templates/General/hypershift-performance-v2.jsonnet > rendered/General/hypershift-performance-v2.json
Building template templates/General/k8s-perf-v2.jsonnet
mkdir -p rendered/General/
bin/jsonnet -J ./templates/vendor templates/General/k8s-perf-v2.jsonnet > rendered/General/k8s-perf-v2.json
Building template templates/General/kube-burner-v2.jsonnet
mkdir -p rendered/General/
bin/jsonnet -J ./templates/vendor templates/General/kube-burner-v2.jsonnet > rendered/General/kube-burner-v2.json
Building template templates/General/ocp-performance-v2.jsonnet
mkdir -p rendered/General/
bin/jsonnet -J ./templates/vendor templates/General/ocp-performance-v2.jsonnet > rendered/General/ocp-performance-v2.json
Building template templates/General/ovn-monitoring-v2.jsonnet
mkdir -p rendered/General/
bin/jsonnet -J ./templates/vendor templates/General/ovn-monitoring-v2.jsonnet > rendered/General/ovn-monitoring-v2.json
Building template templates/General/pgbench-dashboard-v2.jsonnet
mkdir -p rendered/General/
bin/jsonnet -J ./templates/vendor templates/General/pgbench-dashboard-v2.jsonnet > rendered/General/pgbench-dashboard-v2.json
Building template templates/General/uperf-v2.jsonnet
mkdir -p rendered/General/
bin/jsonnet -J ./templates/vendor templates/General/uperf-v2.jsonnet > rendered/General/uperf-v2.json
Building template templates/General/vegeta-wrapper-v2.jsonnet
mkdir -p rendered/General/
bin/jsonnet -J ./templates/vendor templates/General/vegeta-wrapper-v2.jsonnet > rendered/General/vegeta-wrapper-v2.json
Building template templates/General/ycsb-v2.jsonnet
mkdir -p rendered/General/
bin/jsonnet -J ./templates/vendor templates/General/ycsb-v2.jsonnet > rendered/General/ycsb-v2.json
Rendered the v2 dashboards with latest grafonnet library
# podman build --platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x -f Dockerfile --manifest=quay.io/suprajamanda/smanda-dittybopper-syncer:latest .
sudo podman build -f Dockerfile -t=quay.io/suprajamanda/smanda-dittybopper-syncer:latest .
[sudo] password for smanda: 
STEP 1/7: FROM registry.access.redhat.com/ubi8/ubi-minimal
STEP 2/7: WORKDIR /performance-dashboards
--> Using cache 1ab234c4271b432dd69ff47fcb2b92b57d82fd1ca614d5e4aa407a2a1f30af8d
--> 1ab234c4271b
STEP 3/7: RUN microdnf install -y podman python3 python3-pip &&     microdnf clean all &&     rm -rf /var/cache/yum
--> Using cache 973ecfa5d7090389d1aef88132ce2a287e33be070e4dec0dded155483cda8b73
--> 973ecfa5d709
STEP 4/7: COPY . .
--> 8b0394f50080
STEP 5/7: RUN chmod -R 775 /performance-dashboards
--> ec77ea05339a
STEP 6/7: RUN pip3 install --upgrade pip &&     pip3 install -r requirements.txt
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Collecting pip
  Downloading https://files.pythonhosted.org/packages/a4/6d/6463d49a933f547439d6b5b98b46af8742cc03ae83543e4d7688c2420f8b/pip-21.3.1-py3-none-any.whl (1.7MB)
Installing collected packages: pip
Successfully installed pip-21.3.1
WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip.
Please see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue.
To avoid this problem you can invoke Python with '-m pip' instead of running pip directly.
Collecting requests==2.26.0
  Downloading requests-2.26.0-py2.py3-none-any.whl (62 kB)
Collecting certifi>=2017.4.17
  Downloading certifi-2024.2.2-py3-none-any.whl (163 kB)
Collecting urllib3<1.27,>=1.21.1
  Downloading urllib3-1.26.18-py2.py3-none-any.whl (143 kB)
Collecting charset-normalizer~=2.0.0
  Downloading charset_normalizer-2.0.12-py3-none-any.whl (39 kB)
Collecting idna<4,>=2.5
  Downloading idna-3.7-py3-none-any.whl (66 kB)
Installing collected packages: urllib3, idna, charset-normalizer, certifi, requests
Successfully installed certifi-2024.2.2 charset-normalizer-2.0.12 idna-3.7 requests-2.26.0 urllib3-1.26.18
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
--> e28cf39abf51
STEP 7/7: CMD ["python3", "dittybopper/syncer/entrypoint.py"]
COMMIT quay.io/suprajamanda/smanda-dittybopper-syncer:latest
--> 5b1c97c2b483
Successfully tagged quay.io/suprajamanda/smanda-dittybopper-syncer:latest
5b1c97c2b483e78aec86016e78d71935641e544aa991748ec3ef43b6c741af1f
make: 'v2' is up to date.
# podman manifest push quay.io/suprajamanda/smanda-dittybopper-syncer:latest quay.io/suprajamanda/smanda-dittybopper-syncer:latest
sudo podman push quay.io/suprajamanda/smanda-dittybopper-syncer:latest
Getting image source signatures
Copying blob cb830ea07438 done   | 
Copying blob 6df9b5f5953b done   | 
Copying blob 9e4acf767fee done   | 
Copying blob 9b74e6682afd skipped: already exists  
Copying blob 395bceae1ad3 skipped: already exists  
Copying config 5b1c97c2b4 done   | 
Writing manifest to image destination
```
Results: http://dittybopper-dittybopper.apps.smanda-ui-testing.perfscale.devcluster.openshift.com/dashboards

- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
