### PR TITLE
Show all three kube-controller-manager because sometimes ...

### DIFF
--- a/assets/kube-burner-report-ocp-wrapper/queries.libsonnet
+++ b/assets/kube-burner-report-ocp-wrapper/queries.libsonnet
@@ -373,7 +373,7 @@ local elasticsearch = g.query.elasticsearch;
           + elasticsearch.bucketAggs.Terms.settings.withOrder('desc')
           + elasticsearch.bucketAggs.Terms.settings.withOrderBy('1')
           + elasticsearch.bucketAggs.Terms.settings.withMinDocCount('1')
-          + elasticsearch.bucketAggs.Terms.settings.withSize("1"),
+          + elasticsearch.bucketAggs.Terms.settings.withSize("3"),
           elasticsearch.bucketAggs.Terms.withField("labels.container.keyword")
           + elasticsearch.bucketAggs.Terms.withId("4")
           + elasticsearch.bucketAggs.Terms.withType('terms')


### PR DESCRIPTION
... they fail over during a run

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There is not always only one active kube-controller-manager during runs.

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.