### PR TITLE
WIP Migration from grafonnet to foundation sdk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# Performance Dashboards - Claude Code Context
+
+## Project Overview
+
+This repo defines Grafana dashboards for performance testing (OpenShift, network benchmarks, etc.). Dashboards were originally built with **Jsonnet + grafonnet** and rendered to JSON via `make build`. We are migrating them to **Go** using the [grafana-foundation-sdk](https://github.com/grafana/grafana-foundation-sdk) Go builders.
+
+## Go Migration (`go/` directory)
+
+### Structure
+- `go/main.go` — Entry point with dashboard registry (`[]dashboardDef{name, category, builderFunc}`). Writes JSON to `go/rendered/<category>/<name>.json`.
+- `go/helpers.go` — Shared Elasticsearch aggregation helpers only (union type wrappers that are too verbose to inline: `dateHistogramBucketAgg`, `termsBucketAgg`, `avgMetric`, `sumMetric`, `countMetric`, etc.).
+- `go/vegeta.go` — Vegeta Wrapper dashboard (ES queries, 3 timeseries + 1 table).
+- `go/uperf.go` — UPerf dashboard (ES queries with Sum/Count metrics and inline scripts).
+- `go/ocp_performance.go` — OpenShift Performance dashboard (Prometheus queries, 10 rows, ~100 panels, stat panels, interval variable, row repeat).
+- `go/go.mod` — Uses local replace directive pointing to `/Users/ancollin/go/src/github.com/grafana/grafana-foundation-sdk/go`.
+
+### Migrated Dashboards
+1. **vegeta-wrapper** (General) — ES/timeseries/table
+2. **uperf-perf** (General) — ES/timeseries/table with Sum metrics and scripts
+3. **ocp-performance** (General) — Prometheus/timeseries/stat/rows with repeat
+
+### Conventions
+- Panel and variable construction stays **inline** in each dashboard file. Do not create helper structs that abstract away the builder pattern.
+- Shared helpers are limited to ES aggregation type wrappers (genuinely verbose due to union type wrapping).
+- Each dashboard file has its own local panel helpers (e.g., `ocpGenericLegend`, `vegetaTimeSeries`) matching the panel variants from the jsonnet assets.
+- Use `make build` (with `source ~/.venv/performance-dashboards/bin/activate`) to build jsonnet dashboards for comparison.
+
+### SDK Patterns & Gotchas
+- **Union types are verbose**: `StringOrMap{String: cog.ToPtr("...")}`, `StringOrArrayOfString{String: &val}`, `BoolOrFloat64{Bool: cog.ToPtr(true)}`. This is because the SDK is auto-generated from Grafana's JSON schema.
+- **Interval variables** need `Current` and `Options` explicitly set (Grafana won't populate them from `query` alone). Use the `intervalOption(val)` helper.
+- **Row GridPos W must be > 0**: The SDK validates this even though jsonnet allows `w: 0`.
+- **`$Datasource` vs `${Datasource}`**: Both are valid Grafana syntax; the SDK produces the braces form.
+- **`DatasourceVariableBuilder` has no `Refresh` method** — just omit it.
+- **`FieldColorModeIdThresholds`** lives in the `dashboard` package, not `common`.
+- **Expected diff categories** between jsonnet and Go output: `schemaVersion`, auto-generated `id` fields, `pluginVersion`, `repeatDirection`, `transparent: false`, `overrides: []`, per-target datasource refs, `annotations: {}`, `fiscalYearStartMonth`.
+
+### Remaining Dashboards to Migrate
+Check `templates/` directory for the full list. ~13 dashboards remain after OCP Performance.
+
+## Build & Test
+```bash
+# Build Go dashboards
+cd go && go run .
+
+# Build jsonnet dashboards (for comparison)
+source ~/.venv/performance-dashboards/bin/activate && make build
+
+# Compare outputs
+diff <(jq -S . rendered/General/<name>.json) <(jq -S . go/rendered/General/<name>.json)
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN CGO_ENABLED=0 go build -o /deployer .
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 COPY --from=builder /deployer /usr/local/bin/deployer
 COPY rendered/ /dashboards/rendered/
-CMD ["deployer", "--deploy", "--loop", "--input-dir", "/dashboards/rendered"]
+CMD ["deployer", "--deploy", "--input-dir", "/dashboards/rendered"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,11 @@
+FROM golang:1.23 AS builder
+WORKDIR /build
+COPY go/go.mod go/go.sum ./
+RUN go mod download
+COPY go/ ./
+RUN CGO_ENABLED=0 go build -o /deployer .
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal
-
-# Set the working directory
-WORKDIR /performance-dashboards
-
-# Install necessary libraries for subsequent commands
-RUN microdnf install -y podman python3 python3-pip && \
-    microdnf clean all && \
-    rm -rf /var/cache/yum
-
-COPY . .
-
-# Set permissions
-RUN chmod -R 775 /performance-dashboards
-
-# Install dependencies
-RUN pip3 install --no-cache-dir --upgrade pip && \
-    pip3 install --no-cache-dir -r requirements.txt
-
-# Start the command
-CMD ["python3", "dittybopper/syncer/entrypoint.py"]
+COPY --from=builder /deployer /usr/local/bin/deployer
+COPY rendered/ /dashboards/rendered/
+CMD ["deployer", "--deploy", "--loop", "--input-dir", "/dashboards/rendered"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,5 @@ COPY go/ ./
 RUN CGO_ENABLED=0 go build -o /deployer .
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
-COPY --from=builder /deployer /usr/local/bin/deployer
-COPY rendered/ /dashboards/rendered/
-CMD ["deployer", "--deploy", "--input-dir", "/dashboards/rendered"]
+COPY --from=builder /deployer /deployer
+ENTRYPOINT ["/deployer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM golang:1.23 AS builder
-WORKDIR /build
+#TODO needs to specify which golang
+FROM rhel8/go-toolset AS builder
+WORKDIR /opt/app-root/src
 COPY go/go.mod go/go.sum ./
 RUN go mod download
 COPY go/ ./
-RUN CGO_ENABLED=0 go build -o /deployer .
+RUN CGO_ENABLED=0 go build -o /opt/app-root/src/deployer .
 
+# Also needs better non-root user management.
+# Getting permission denied trying to run on openshift
 FROM registry.access.redhat.com/ubi8/ubi-minimal
-COPY --from=builder /deployer /deployer
+RUN mkdir /rendered && \
+    chgrp -R 0 /rendered && \
+    chmod -R g=u /rendered
+COPY --from=builder /opt/app-root/src/deployer /deployer
 ENTRYPOINT ["/deployer"]
+USER 1001

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ $(OUTPUTDIR)/%.json: $(TEMPLATESDIR)/%.jsonnet $(ASSETS)
 	mkdir -p $(dir $@)
 	$(BINDIR)/jsonnet -J ./$(LIBRARY_PATH) $< > $@
 
+build-go:
+	cd go && go build -o ../bin/deployer .
+
+deploy: build-go
+	bin/deployer --deploy
+
 build-syncer-image: build
 	podman build --platform=${PLATFORM} -f Dockerfile --manifest=${SYNCER_IMG_TAG} .
 

--- a/dittybopper/deploy.sh
+++ b/dittybopper/deploy.sh
@@ -39,7 +39,7 @@ END
 # Set default template variables
 export PROMETHEUS_USER=internal
 export GRAFANA_ADMIN_PASSWORD=admin
-export GRAFANA_URL="http://admin:${GRAFANA_ADMIN_PASSWORD}@localhost:3000"
+export GRAFANA_URL="http://admin:${GRAFANA_ADMIN_PASSWORD}@dittybopper.dittybopper.svc:3000"
 export SYNCER_IMAGE=${SYNCER_IMAGE:-"quay.io/cloud-bulldozer/dittybopper-syncer:latest"} # Syncer image
 export GRAFANA_IMAGE=${GRAFANA_IMAGE:-"docker.io/grafana/grafana:12.3.5"} # Grafana image
 export GRAFANA_RENDERER_IMAGE=${GRAFANA_RENDERER_IMAGE:-"docker.io/grafana/grafana-image-renderer:v5.7.1"} # Grafana renderer image

--- a/dittybopper/deploy.sh
+++ b/dittybopper/deploy.sh
@@ -40,7 +40,7 @@ END
 export PROMETHEUS_USER=internal
 export GRAFANA_ADMIN_PASSWORD=admin
 export GRAFANA_URL="http://admin:${GRAFANA_ADMIN_PASSWORD}@dittybopper.dittybopper.svc:3000"
-export SYNCER_IMAGE=${SYNCER_IMAGE:-"quay.io/cloud-bulldozer/dittybopper-syncer:latest"} # Syncer image
+export SYNCER_IMAGE=${SYNCER_IMAGE:-"quay.io/afcollins/dittybopper-syncer:go-sdk-6afa65a-amd64"} # Syncer image
 export GRAFANA_IMAGE=${GRAFANA_IMAGE:-"docker.io/grafana/grafana:12.3.5"} # Grafana image
 export GRAFANA_RENDERER_IMAGE=${GRAFANA_RENDERER_IMAGE:-"docker.io/grafana/grafana-image-renderer:v5.7.1"} # Grafana renderer image
 

--- a/dittybopper/templates/dittybopper.yaml.template
+++ b/dittybopper/templates/dittybopper.yaml.template
@@ -104,15 +104,6 @@ spec:
           value: "http://dittybopper.dittybopper.svc:3000/"
         - name: GF_LOG_FILTERS
           value: "rendering:debug"
-      - name: dittybopper-syncer
-        imagePullPolicy: Always
-        command: ["deployer", "--deploy", "--input-dir", "/dashboards/rendered"]
-        env:
-        - name: GRAFANA_URL
-          value: ${GRAFANA_URL}
-        - name: GIT_COMMIT_HASH
-          value: "${GIT_COMMIT_HASH}"
-        image: ${SYNCER_IMAGE}
       volumes:
       - name: sc-grafana-config
         configMap:
@@ -122,6 +113,29 @@ spec:
           name: sc-ocp-prom
       - name: grafana-data
         emptyDir: {}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dittybopper-deploy
+  namespace: $namespace
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app: dittybopper-deploy
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: deployer
+        image: ${SYNCER_IMAGE}
+        args: ["--deploy"]
+        env:
+        - name: GRAFANA_URL
+          value: ${GRAFANA_URL}
+        - name: GIT_COMMIT_HASH
+          value: "${GIT_COMMIT_HASH}"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/dittybopper/templates/dittybopper.yaml.template
+++ b/dittybopper/templates/dittybopper.yaml.template
@@ -106,7 +106,7 @@ spec:
           value: "rendering:debug"
       - name: dittybopper-syncer
         imagePullPolicy: Always
-        command: ["deployer", "--deploy", "--loop", "--input-dir", "/dashboards/rendered"]
+        command: ["deployer", "--deploy", "--input-dir", "/dashboards/rendered"]
         env:
         - name: GRAFANA_URL
           value: ${GRAFANA_URL}

--- a/dittybopper/templates/dittybopper.yaml.template
+++ b/dittybopper/templates/dittybopper.yaml.template
@@ -106,11 +106,12 @@ spec:
           value: "rendering:debug"
       - name: dittybopper-syncer
         imagePullPolicy: Always
+        command: ["deployer", "--deploy", "--loop", "--input-dir", "/dashboards/rendered"]
         env:
         - name: GRAFANA_URL
           value: ${GRAFANA_URL}
-        - name: INPUT_DIR
-          value: "/performance-dashboards/rendered/"
+        - name: GIT_COMMIT_HASH
+          value: "${GIT_COMMIT_HASH}"
         image: ${SYNCER_IMAGE}
       volumes:
       - name: sc-grafana-config

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -1,0 +1,2 @@
+performance-dashboards
+rendered/

--- a/go/api_performance.go
+++ b/go/api_performance.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
+	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
+)
+
+func buildAPIPerformanceDashboard() *dashboard.DashboardBuilder {
+	return dashboard.NewDashboardBuilder("API Performance Dashboard").
+		Description("Dashboard for Api-performance-overview\n").
+		Tags([]string{"Api-performance"}).
+		Time("now-1h", "now").
+		Timezone("utc").
+		Refresh("30s").
+		Readonly().
+		Tooltip(dashboard.DashboardCursorSyncCrosshair).
+		WithVariable(dashboard.NewDatasourceVariableBuilder("Datasource").
+			Type("prometheus").
+			Regex("").
+			Label("Datasource"),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("apiserver").
+			Label("apiserver").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(apiserver_request_duration_seconds_bucket, apiserver)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("instance").
+			Label("instance").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(apiserver_request_total, instance)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("resource").
+			Label("resource").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(apiserver_request_duration_seconds_bucket, resource)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("code").
+			Label("code").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(code)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("verb").
+			Label("verb").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(verb)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("flow_schema").
+			Label("flow-schema").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(flow_schema)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("priority_level").
+			Label("priority-level").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(priority_level)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewIntervalVariableBuilder("interval").
+			Label("interval").
+			Values(dashboard.StringOrMap{String: cog.ToPtr("1m,5m")}).
+			Auto(true).
+			StepCount(30).
+			MinInterval("10s").
+			Current(intervalOption("1m")).
+			Options([]dashboard.VariableOption{
+				intervalOption("1m"),
+				intervalOption("5m"),
+			}),
+		).
+		WithPanel(apiLegendRight("request duration - 99th quantile", "s",
+			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",subresource!="log",verb=~"$verb",verb!~"WATCH|WATCHLIST|PROXY"}[$interval])) by(verb,le))`, "{{verb}}"),
+		)).
+		WithPanel(apiLegendRight("request rate - by instance", "short",
+			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 8},
+			promQuery(`sum(rate(apiserver_request_total{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",code=~"$code",verb=~"$verb"}[$interval])) by(instance)`, "{{instance}}"),
+		)).
+		WithPanel(apiLegendRight("request duration - 99th quantile - by resource", "s",
+			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",subresource!="log",verb=~"$verb",verb!~"WATCH|WATCHLIST|PROXY"}[$interval])) by(resource,le))`, "{{resource}}"),
+		)).
+		WithPanel(apiLegendRight("request rate - by resource", "short",
+			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 8},
+			promQuery(`sum(rate(apiserver_request_total{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",code=~"$code",verb=~"$verb"}[$interval])) by(resource)`, "{{resource}}"),
+		)).
+		WithPanel(apiLegendBottom("request duration - read vs write", "s",
+			dashboard.GridPos{X: 0, Y: 16, W: 12, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",verb=~"LIST|GET"}[$interval])) by(le))`, "read"),
+			promQuery(`histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[$interval])) by(le))`, "write"),
+		)).
+		WithPanel(apiLegendBottom("request rate - read vs write", "short",
+			dashboard.GridPos{X: 12, Y: 16, W: 12, H: 8},
+			promQuery(`sum(rate(apiserver_request_total{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",verb=~"LIST|GET"}[$interval]))`, "read"),
+			promQuery(`sum(rate(apiserver_request_total{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[$interval]))`, "write"),
+		)).
+		WithPanel(apiLegendBottom("requests dropped rate", "short",
+			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
+			promQuery(`sum(rate(apiserver_request_terminations_total{instance=~"$instance"}[$interval])) by (verb)`, ""),
+		)).
+		WithPanel(apiLegendBottom("requests terminated rate", "short",
+			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
+			promQuery(`sum(rate(apiserver_request_terminations_total{instance=~"$instance",resource=~"$resource",code=~"$code"}[$interval])) by(component)`, ""),
+		)).
+		WithPanel(apiLegendRight("requests status rate", "short",
+			dashboard.GridPos{X: 0, Y: 32, W: 12, H: 8},
+			promQuery(`sum(rate(apiserver_request_total{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",verb=~"$verb",code=~"$code"}[$interval])) by(code)`, "{{code}}"),
+		)).
+		WithPanel(apiLegendRight("long running requests", "short",
+			dashboard.GridPos{X: 12, Y: 32, W: 12, H: 8},
+			promQuery(`sum(apiserver_longrunning_requests{instance=~"$instance",resource=~"$resource",verb=~"$verb"}) by(instance)`, "{{instance}}"),
+		)).
+		WithPanel(apiLegendRight("request in flight", "short",
+			dashboard.GridPos{X: 0, Y: 40, W: 12, H: 8},
+			promQuery(`sum(apiserver_current_inflight_requests{instance=~"$instance"}) by (instance,request_kind)`, "{{request_kind}}-{{instance}}"),
+		)).
+		WithPanel(apiLegendRight("response size - 99th quantile", "bytes",
+			dashboard.GridPos{X: 12, Y: 40, W: 12, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(apiserver_response_sizes_bucket{instance=~"$instance",resource=~"$resource",verb=~"$verb"}[$interval])) by(instance,le))`, "{{instance}}"),
+		)).
+		WithPanel(apiLegendRight("p&f - request queue length", "short",
+			dashboard.GridPos{X: 0, Y: 48, W: 12, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(apiserver_flowcontrol_request_queue_length_after_enqueue_bucket{instance=~"$instance",flow_schema=~"$flow_schema",priority_level=~"$priority_level"}[$interval])) by(flow_schema, priority_level, le))`, "{{flow_schema}}:{{priority_level}}"),
+		)).
+		WithPanel(apiWaitDuration("p&f - request wait duration - 99th quantile", "s",
+			dashboard.GridPos{X: 12, Y: 48, W: 12, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(apiserver_flowcontrol_request_wait_duration_seconds_bucket{instance=~"$instance",flow_schema=~"$flow_schema",priority_level=~"$priority_level"}[5m])) by(flow_schema, priority_level, le))`, "{{flow_schema}}:{{priority_level}}"),
+		)).
+		WithPanel(apiLegendRight("p&f - request dispatch rate", "short",
+			dashboard.GridPos{X: 0, Y: 64, W: 12, H: 8},
+			promQuery(`sum(rate(apiserver_flowcontrol_dispatched_requests_total{instance=~"$instance",flow_schema=~"$flow_schema",priority_level=~"$priority_level"}[$interval])) by(flow_schema,priority_level)`, "{{flow_schema}}:{{priority_level}}"),
+		)).
+		WithPanel(apiLegendRight("p&f - request execution duration", "s",
+			dashboard.GridPos{X: 12, Y: 64, W: 12, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(apiserver_flowcontrol_request_execution_seconds_bucket{instance=~"$instance",flow_schema=~"$flow_schema",priority_level=~"$priority_level"}[$interval])) by(flow_schema, priority_level, le))`, "{{flow_schema}}:{{priority_level}}"),
+		)).
+		WithPanel(apiLegendRight("p&f - pending in queue", "short",
+			dashboard.GridPos{X: 0, Y: 72, W: 12, H: 8},
+			promQuery(`sum(apiserver_flowcontrol_current_inqueue_requests{instance=~"$instance",flow_schema=~"$flow_schema",priority_level=~"$priority_level"}) by (flow_schema,priority_level)`, "{{flow_schema}}:{{priority_level}}"),
+		)).
+		WithPanel(apiLegendRight("p&f - concurrency limit by kube-apiserver", "short",
+			dashboard.GridPos{X: 12, Y: 72, W: 12, H: 8},
+			promQuery(`sum(apiserver_flowcontrol_request_concurrency_in_use{instance=~".*:6443",priority_level=~"$priority_level"}) by (instance,flow_schema)`, "{{instance}}:{{flow_schema}}"),
+		))
+}
+
+func apiBase(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	p := timeseries.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		DrawStyle(common.GraphDrawStyleLine).
+		LineInterpolation(common.LineInterpolationLinear).
+		BarAlignment(common.BarAlignmentCenter).
+		LineWidth(1).
+		FillOpacity(10).
+		GradientMode(common.GraphGradientModeNone).
+		SpanNulls(boolPtr(false)).
+		PointSize(5).
+		ShowPoints(common.VisibilityModeNever).
+		Stacking(common.NewStackingConfigBuilder().
+			Group("A").
+			Mode(common.StackingModeNone),
+		).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Sort(common.SortOrderDescending),
+		).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			SortBy("Max").
+			SortDesc(true),
+		)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}
+
+func apiLegendRight(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	return apiBase(title, unit, gridPos, targets...).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderDescending),
+		).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			DisplayMode(common.LegendDisplayModeTable).
+			Placement(common.LegendPlacementRight).
+			Calcs([]string{"max"}).
+			SortBy("Max").
+			SortDesc(true),
+		)
+}
+
+func apiLegendBottom(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	return apiBase(title, unit, gridPos, targets...).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderDescending),
+		).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			DisplayMode(common.LegendDisplayModeList).
+			Placement(common.LegendPlacementBottom).
+			SortBy("Max").
+			SortDesc(true),
+		)
+}
+
+func apiWaitDuration(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	return apiLegendRight(title, unit, gridPos, targets...).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			DisplayMode(common.LegendDisplayModeTable).
+			Placement(common.LegendPlacementRight).
+			Calcs([]string{"mean", "max", "lastNotNull"}).
+			SortBy("Max").
+			SortDesc(true),
+		)
+}

--- a/go/deploy.go
+++ b/go/deploy.go
@@ -161,7 +161,7 @@ func (d *deployer) uploadDashboard(jsonPath string, folderID int) error {
 	payload, _ := json.Marshal(map[string]interface{}{
 		"dashboard": dash,
 		"folderId":  folderID,
-		"overwrite": true,
+		"overwrite": false,
 	})
 
 	resp, err := http.Post(d.grafanaURL+"/api/dashboards/db", "application/json", bytes.NewReader(payload))
@@ -170,12 +170,17 @@ func (d *deployer) uploadDashboard(jsonPath string, folderID int) error {
 	}
 	defer resp.Body.Close()
 
+	title, _ := dash["title"].(string)
+
+	if resp.StatusCode == http.StatusPreconditionFailed {
+		log.Printf("skipped %q (already exists)", title)
+		return nil
+	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("status %d: %s", resp.StatusCode, string(body))
 	}
 
-	title, _ := dash["title"].(string)
 	log.Printf("deployed %q to folder %d", title, folderID)
 	return nil
 }

--- a/go/deploy.go
+++ b/go/deploy.go
@@ -146,8 +146,12 @@ func (d *deployer) uploadDashboard(jsonPath string, folderID int) error {
 		return fmt.Errorf("parsing %s: %w", jsonPath, err)
 	}
 
-	// Remove id so Grafana treats it as new/upsert
+	// Remove id and set a stable uid derived from the title so Grafana
+	// upserts instead of creating duplicates on each sync.
 	delete(dash, "id")
+	if title, ok := dash["title"].(string); ok && title != "" {
+		dash["uid"] = uuid.NewSHA1(uuid.NameSpaceDNS, []byte(title)).String()
+	}
 
 	if d.gitCommitHash != "" {
 		tags, _ := dash["tags"].([]interface{})

--- a/go/deploy.go
+++ b/go/deploy.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+type deployer struct {
+	grafanaURL    string
+	inputDir      string
+	gitCommitHash string
+	folderMap     map[string]int // folder title -> folder id
+}
+
+func newDeployer(grafanaURL, inputDir, gitCommitHash string) *deployer {
+	return &deployer{
+		grafanaURL:    strings.TrimRight(grafanaURL, "/"),
+		inputDir:      inputDir,
+		gitCommitHash: gitCommitHash,
+		folderMap:     make(map[string]int),
+	}
+}
+
+func (d *deployer) deploy() error {
+	if err := d.fetchFolders(); err != nil {
+		return fmt.Errorf("fetching folders: %w", err)
+	}
+
+	dashboards, err := d.discoverDashboards()
+	if err != nil {
+		return fmt.Errorf("discovering dashboards: %w", err)
+	}
+
+	for folderID, files := range dashboards {
+		for _, f := range files {
+			if err := d.uploadDashboard(f, folderID); err != nil {
+				return fmt.Errorf("uploading %s: %w", f, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (d *deployer) fetchFolders() error {
+	resp, err := http.Get(d.grafanaURL + "/api/folders")
+	if err != nil {
+		return fmt.Errorf("GET /api/folders: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var folders []struct {
+		ID    int    `json:"id"`
+		Title string `json:"title"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&folders); err != nil {
+		return fmt.Errorf("decoding folders: %w", err)
+	}
+
+	for _, f := range folders {
+		d.folderMap[f.Title] = f.ID
+	}
+	return nil
+}
+
+func (d *deployer) discoverDashboards() (map[int][]string, error) {
+	result := make(map[int][]string)
+
+	err := filepath.Walk(d.inputDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".json") {
+			return nil
+		}
+
+		rel, _ := filepath.Rel(d.inputDir, path)
+		parts := strings.SplitN(rel, string(filepath.Separator), 2)
+
+		var folderName string
+		if len(parts) == 2 {
+			folderName = parts[0]
+		} else {
+			folderName = "General"
+		}
+
+		folderID, err := d.ensureFolder(folderName)
+		if err != nil {
+			return err
+		}
+		result[folderID] = append(result[folderID], path)
+		return nil
+	})
+	return result, err
+}
+
+func (d *deployer) ensureFolder(name string) (int, error) {
+	if name == "General" {
+		return 0, nil
+	}
+	if id, ok := d.folderMap[name]; ok {
+		return id, nil
+	}
+	return d.createFolder(name)
+}
+
+func (d *deployer) createFolder(name string) (int, error) {
+	body, _ := json.Marshal(map[string]string{
+		"title": name,
+		"uid":   uuid.New().String(),
+	})
+
+	resp, err := http.Post(d.grafanaURL+"/api/folders", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("POST /api/folders: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		ID int `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("decoding create-folder response: %w", err)
+	}
+
+	d.folderMap[name] = result.ID
+	return result.ID, nil
+}
+
+func (d *deployer) uploadDashboard(jsonPath string, folderID int) error {
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		return err
+	}
+
+	var dash map[string]interface{}
+	if err := json.Unmarshal(data, &dash); err != nil {
+		return fmt.Errorf("parsing %s: %w", jsonPath, err)
+	}
+
+	// Remove id so Grafana treats it as new/upsert
+	delete(dash, "id")
+
+	if d.gitCommitHash != "" {
+		tags, _ := dash["tags"].([]interface{})
+		dash["tags"] = append(tags, d.gitCommitHash)
+	}
+
+	payload, _ := json.Marshal(map[string]interface{}{
+		"dashboard": dash,
+		"folderId":  folderID,
+		"overwrite": true,
+	})
+
+	resp, err := http.Post(d.grafanaURL+"/api/dashboards/db", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("POST /api/dashboards/db: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status %d: %s", resp.StatusCode, string(body))
+	}
+
+	title, _ := dash["title"].(string)
+	log.Printf("deployed %q to folder %d", title, folderID)
+	return nil
+}

--- a/go/deploy.go
+++ b/go/deploy.go
@@ -55,7 +55,11 @@ func (d *deployer) fetchFolders() error {
 	if err != nil {
 		return fmt.Errorf("GET /api/folders: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("error closing response body: %v", err)
+		}
+	}()
 
 	var folders []struct {
 		ID    int    `json:"id"`
@@ -122,7 +126,11 @@ func (d *deployer) createFolder(name string) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("POST /api/folders: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("error closing response body: %v", err)
+		}
+	}()
 
 	var result struct {
 		ID int `json:"id"`
@@ -168,7 +176,11 @@ func (d *deployer) uploadDashboard(jsonPath string, folderID int) error {
 	if err != nil {
 		return fmt.Errorf("POST /api/dashboards/db: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("error closing response body: %v", err)
+		}
+	}()
 
 	title, _ := dash["title"].(string)
 

--- a/go/etcd.go
+++ b/go/etcd.go
@@ -1,0 +1,384 @@
+package main
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
+	"github.com/grafana/grafana-foundation-sdk/go/stat"
+	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
+)
+
+func buildEtcdDashboard() *dashboard.DashboardBuilder {
+	return dashboard.NewDashboardBuilder("etcd-cluster-info dashboard").
+		Time("now-1h", "now").
+		Timezone("utc").
+		Timepicker(dashboard.NewTimePickerBuilder().
+			RefreshIntervals([]string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}),
+		).
+		Refresh("").
+		Readonly().
+		Tooltip(dashboard.DashboardCursorSyncCrosshair).
+		WithVariable(dashboard.NewDatasourceVariableBuilder("Datasource").
+			Type("prometheus").
+			Regex("").
+			Label("Datasource"),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("etcd_pod").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(etcd_cluster_version, pod)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(true).
+			IncludeAll(true),
+		).
+		WithRow(etcdGeneralResourceUsageRow()).
+		WithRow(etcdCompactDefragRow()).
+		WithRow(etcdWALFsyncRow()).
+		WithRow(etcdBackendCommitRow()).
+		WithRow(etcdNetworkUsageRow()).
+		WithRow(etcdDBInfoRow()).
+		WithRow(etcdGeneralInfoRow())
+}
+
+// base timeseries for etcd panels
+func etcdBase(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	p := timeseries.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		DrawStyle(common.GraphDrawStyleLine).
+		LineInterpolation(common.LineInterpolationLinear).
+		BarAlignment(common.BarAlignmentCenter).
+		LineWidth(1).
+		FillOpacity(10).
+		GradientMode(common.GraphGradientModeNone).
+		SpanNulls(boolPtr(false)).
+		PointSize(5).
+		ShowPoints(common.VisibilityModeNever).
+		Stacking(common.NewStackingConfigBuilder().
+			Mode(common.StackingModeNone),
+		).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderDescending),
+		).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			Placement(common.LegendPlacementBottom),
+		)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}
+
+func etcdGeneralUsageAgg(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	return etcdBase(title, unit, gridPos, targets...).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			Placement(common.LegendPlacementBottom).
+			DisplayMode(common.LegendDisplayModeTable).
+			Calcs([]string{"mean", "max"}).
+			SortBy("Max").
+			SortDesc(true),
+		)
+}
+
+func etcdGeneralCounter(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	return etcdBase(title, unit, gridPos, targets...).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			Placement(common.LegendPlacementBottom).
+			Calcs([]string{"first", "min", "max", "last"}),
+		)
+}
+
+func etcdHistogramStatsRightHand(title, unit string, gridPos dashboard.GridPos, leftAxis string, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	return etcdGeneralCounter(title, unit, gridPos, targets...).
+		AxisLabel(leftAxis).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			Placement(common.LegendPlacementBottom).
+			DisplayMode(common.LegendDisplayModeTable).
+			Calcs([]string{"first", "min", "max", "last"}).
+			SortBy("Max"),
+		).
+		OverrideByRegexp(".*rate.*", []dashboard.DynamicConfigValue{
+			{Id: "custom.axisPlacement", Value: "right"},
+			{Id: "custom.axisLabel", Value: "rate"},
+			{Id: "unit", Value: "none"},
+		})
+}
+
+func etcdWithoutCalcsAgg(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	return etcdBase(title, unit, gridPos, targets...).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			Placement(common.LegendPlacementBottom).
+			DisplayMode(common.LegendDisplayModeTable).
+			Calcs([]string{}),
+		)
+}
+
+func etcdGeneralInfo(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	return etcdBase(title, unit, gridPos, targets...).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			Placement(common.LegendPlacementBottom).
+			DisplayMode(common.LegendDisplayModeList).
+			Calcs([]string{}),
+		)
+}
+
+func etcdStatBase(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *stat.PanelBuilder {
+	p := stat.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		JustifyMode(common.BigValueJustifyModeAuto).
+		GraphMode(common.BigValueGraphModeNone).
+		Text(common.NewVizTextDisplayOptionsBuilder().
+			TitleSize(12),
+		).
+		ColorScheme(dashboard.NewFieldColorBuilder().
+			Mode(dashboard.FieldColorModeIdThresholds),
+		).
+		ColorMode(common.BigValueColorModeNone)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}
+
+// Row: General Resource Usage
+func etcdGeneralResourceUsageRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("General Resource Usage").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 14, W: 24, H: 1}).
+		WithPanel(etcdGeneralUsageAgg("CPU usage", "percent",
+			dashboard.GridPos{X: 0, Y: 1, W: 12, H: 8},
+			promQuery(`sum(irate(container_cpu_usage_seconds_total{namespace="openshift-etcd", container="etcd",pod=~"$etcd_pod"}[2m])) by (pod) * 100`, "{{ pod }}"),
+		)).
+		WithPanel(etcdGeneralUsageAgg("Memory usage", "bytes",
+			dashboard.GridPos{X: 12, Y: 1, W: 12, H: 8},
+			promQuery(`sum(avg_over_time(container_memory_working_set_bytes{container="",pod!="", namespace=~"openshift-etcd.*",pod=~"$etcd_pod"}[2m])) BY (pod, namespace)`, "{{ pod }}"),
+		)).
+		WithPanel(etcdGeneralUsageAgg("Disk WAL Sync Duration", "s",
+			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[5m])) by (pod, le))`, "{{pod}} WAL fsync"),
+		)).
+		WithPanel(etcdGeneralUsageAgg("Disk Backend Sync Duration", "s",
+			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[5m])) by (pod, le))`, "{{pod}} DB fsync"),
+		)).
+		WithPanel(etcdGeneralUsageAgg("Etcd container disk writes", "Bps",
+			dashboard.GridPos{X: 0, Y: 16, W: 12, H: 8},
+			promQuery(`rate(container_fs_writes_bytes_total{namespace="openshift-etcd",device!~".+dm.+"}[2m])`, "{{ pod }}: {{ device }}"),
+		)).
+		WithPanel(etcdGeneralUsageAgg("DB Size", "bytes",
+			dashboard.GridPos{X: 12, Y: 16, W: 12, H: 8},
+			promQuery(`etcd_mvcc_db_total_size_in_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{pod}} DB physical size"),
+			promQuery(`etcd_mvcc_db_total_size_in_use_in_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{pod}} DB logical size"),
+		))
+}
+
+// Row: Compact/Defrag Detailed
+func etcdCompactDefragRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Compact/Defrag Detailed").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 14, W: 24, H: 1}).
+		WithPanel(etcdHistogramStatsRightHand("Compaction Duration sum", "none",
+			dashboard.GridPos{X: 0, Y: 0, W: 8, H: 8}, "sum",
+			promQuery(`delta(etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}[1m:30s])/2`, "rate compact sum {{instance}} "),
+			promQuery(`etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "compact sum {{instance}} "),
+		)).
+		WithPanel(etcdHistogramStatsRightHand("Defrag Duration sum", "none",
+			dashboard.GridPos{X: 8, Y: 0, W: 8, H: 8}, "count",
+			promQuery(`delta(etcd_disk_backend_defrag_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}[1m:30s])/2`, "rate defrag sum {{instance}} "),
+			promQuery(`etcd_disk_backend_defrag_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "defrag sum {{instance}} "),
+		)).
+		WithPanel(etcdHistogramStatsRightHand("vmstat major page faults", "none",
+			dashboard.GridPos{X: 16, Y: 0, W: 8, H: 8}, "count",
+			promQuery(`rate(node_vmstat_pgmajfault[2m])* on (instance) group_left label_replace(kube_node_role{role="control-plane"},"instance","$1","node","(.*)")`, "rate pgmajfault {{instance}} "),
+			promQuery(`node_vmstat_pgmajfault * on (instance) group_left label_replace(kube_node_role{role="control-plane"},"instance","$1","node","(.*)")`, "pgmajfault {{instance}} "),
+		))
+}
+
+// Row: WAL fsync Duration Detailed
+func etcdWALFsyncRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("WAL fsync Duration Detailed").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 14, W: 24, H: 1}).
+		WithPanel(etcdGeneralUsageAgg("WAL fsync Duration p99", "s",
+			dashboard.GridPos{X: 0, Y: 0, W: 8, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[5m])) by (pod, le))`, "{{pod}} WAL fsync"),
+		)).
+		WithPanel(etcdHistogramStatsRightHand("WAL fsync Duration sum", "none",
+			dashboard.GridPos{X: 8, Y: 0, W: 8, H: 8}, "sum",
+			promQuery(`irate(etcd_disk_wal_fsync_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "2m irate WAL sum {{instance}} "),
+			promQuery(`etcd_disk_wal_fsync_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "WAL sum {{instance}} "),
+		)).
+		WithPanel(etcdHistogramStatsRightHand("WAL fsync Duration count", "none",
+			dashboard.GridPos{X: 16, Y: 0, W: 8, H: 8}, "count",
+			promQuery(`irate(etcd_disk_wal_fsync_duration_seconds_count{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "2m irate WAL count {{instance}} "),
+			promQuery(`etcd_disk_wal_fsync_duration_seconds_count{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "WAL count {{instance}} "),
+		))
+}
+
+// Row: Backend Commit Duration Detailed
+func etcdBackendCommitRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Backend Commit Duration Detailed").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 14, W: 24, H: 1}).
+		WithPanel(etcdGeneralUsageAgg("Backend Commit Duration", "s",
+			dashboard.GridPos{X: 0, Y: 0, W: 8, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[5m])) by (pod, le))`, "{{pod}} DB fsync"),
+		)).
+		WithPanel(etcdHistogramStatsRightHand("Backend Commit Duration sum", "none",
+			dashboard.GridPos{X: 8, Y: 0, W: 8, H: 8}, "sum",
+			promQuery(`irate(etcd_disk_backend_commit_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "2m irate WAL sum {{instance}} "),
+			promQuery(`etcd_disk_backend_commit_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "WAL sum {{instance}} "),
+		)).
+		WithPanel(etcdHistogramStatsRightHand("Backend Commit Duration count", "none",
+			dashboard.GridPos{X: 16, Y: 0, W: 8, H: 8}, "count",
+			promQuery(`irate(etcd_disk_backend_commit_duration_seconds_count{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "2m irate WAL count {{instance}} "),
+			promQuery(`etcd_disk_backend_commit_duration_seconds_count{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "WAL count {{instance}} "),
+		))
+}
+
+// Row: Network Usage
+func etcdNetworkUsageRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Network Usage").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 14, W: 24, H: 1}).
+		WithPanel(etcdGeneralUsageAgg("Container network traffic", "Bps",
+			dashboard.GridPos{X: 0, Y: 1, W: 12, H: 8},
+			promQuery(`sum(rate(container_network_receive_bytes_total{ namespace=~"openshift-etcd.*"}[2m])) BY (namespace, pod)`, "rx {{ pod }}"),
+			promQuery(`sum(rate(container_network_transmit_bytes_total{ namespace=~"openshift-etcd.*"}[2m])) BY (namespace, pod)`, "tx {{ pod }}"),
+		)).
+		WithPanel(etcdGeneralUsageAgg("p99 peer to peer latency", "s",
+			dashboard.GridPos{X: 12, Y: 1, W: 12, H: 8},
+			promQuery(`histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m]))`, "{{pod}}"),
+		)).
+		WithPanel(etcdGeneralUsageAgg("Peer network traffic", "Bps",
+			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 8},
+			promQuery(`rate(etcd_network_peer_received_bytes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "rx {{pod}} Peer Traffic"),
+			promQuery(`rate(etcd_network_peer_sent_bytes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "tx {{pod}} Peer Traffic"),
+		)).
+		WithPanel(etcdGeneralUsageAgg("gRPC network traffic", "Bps",
+			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 8},
+			promQuery(`rate(etcd_network_client_grpc_received_bytes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "rx {{pod}}"),
+			promQuery(`rate(etcd_network_client_grpc_sent_bytes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "tx {{pod}}"),
+		)).
+		WithPanel(etcdWithoutCalcsAgg("Active Streams", "",
+			dashboard.GridPos{X: 0, Y: 16, W: 12, H: 8},
+			promQuery(`sum(grpc_server_started_total{namespace="openshift-etcd",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{namespace="openshift-etcd",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"})`, "Watch Streams"),
+			promQuery(`sum(grpc_server_started_total{namespace="openshift-etcd",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{namespace="openshift-etcd",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"})`, "Lease Streams"),
+		)).
+		WithPanel(etcdWithoutCalcsAgg("Snapshot duration", "s",
+			dashboard.GridPos{X: 12, Y: 16, W: 12, H: 8},
+			promQuery(`sum(rate(etcd_debugging_snap_save_total_duration_seconds_sum{namespace="openshift-etcd"}[2m]))`, "the total latency distributions of save called by snapshot"),
+		))
+}
+
+// Row: DB Info per Member
+func etcdDBInfoRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("DB Info per Member").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 14, W: 24, H: 1}).
+		WithPanel(etcdWithoutCalcsAgg("% DB Space Used", "percent",
+			dashboard.GridPos{X: 0, Y: 8, W: 8, H: 8},
+			promQuery(`(etcd_mvcc_db_total_size_in_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"} / etcd_server_quota_backend_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"})*100`, "{{pod}}"),
+		)).
+		WithPanel(etcdWithoutCalcsAgg("DB Left capacity (with fragmented space)", "bytes",
+			dashboard.GridPos{X: 8, Y: 8, W: 8, H: 8},
+			promQuery(`etcd_server_quota_backend_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"} - etcd_mvcc_db_total_size_in_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{pod}}"),
+		)).
+		WithPanel(etcdWithoutCalcsAgg("DB Size Limit (Backend-bytes)", "bytes",
+			dashboard.GridPos{X: 16, Y: 8, W: 8, H: 8},
+			promQuery(`etcd_server_quota_backend_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod }} Quota Bytes"),
+		))
+}
+
+// Row: General Info
+func etcdGeneralInfoRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("General Info").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 14, W: 24, H: 1}).
+		WithPanel(etcdGeneralInfo("Raft Proposals", "",
+			dashboard.GridPos{X: 0, Y: 1, W: 12, H: 8},
+			promQuery(`sum(rate(etcd_server_proposals_failed_total{namespace="openshift-etcd"}[2m]))`, "Proposal Failure Rate"),
+			promQuery(`sum(etcd_server_proposals_pending{namespace="openshift-etcd"})`, "Proposal Pending Total"),
+			promQuery(`sum(rate(etcd_server_proposals_committed_total{namespace="openshift-etcd"}[2m]))`, "Proposal Commit Rate"),
+			promQuery(`sum(rate(etcd_server_proposals_applied_total{namespace="openshift-etcd"}[2m]))`, "Proposal Apply Rate"),
+		)).
+		WithPanel(etcdGeneralInfo("Number of leader changes seen", "",
+			dashboard.GridPos{X: 12, Y: 1, W: 12, H: 8},
+			promQuery(`sum(rate(etcd_server_leader_changes_seen_total{namespace="openshift-etcd"}[2m]))`, ""),
+		)).
+		WithPanel(
+			etcdStatBase("Etcd has a leader?", "none",
+				dashboard.GridPos{X: 0, Y: 8, W: 6, H: 2},
+				promQuery(`max(etcd_server_has_leader{namespace="openshift-etcd"})`, ""),
+			).
+				ReduceOptions(common.NewReduceDataOptionsBuilder().
+					Calcs([]string{"mean"}),
+				).
+				Mappings([]dashboard.ValueMapping{
+					{ValueMap: &dashboard.ValueMap{
+						Type: dashboard.MappingTypeValueToText,
+						Options: map[string]dashboard.ValueMappingResult{
+							"0": {Text: cog.ToPtr("NO")},
+							"1": {Text: cog.ToPtr("YES")},
+						},
+					}},
+				}),
+		).
+		WithPanel(
+			etcdStatBase("Total number of failed proposals seen", "none",
+				dashboard.GridPos{X: 6, Y: 8, W: 6, H: 2},
+				promQuery(`max(etcd_server_proposals_committed_total{namespace="openshift-etcd"})`, ""),
+			).
+				ReduceOptions(common.NewReduceDataOptionsBuilder().
+					Calcs([]string{"mean"}),
+				).
+				Mappings([]dashboard.ValueMapping{
+					{SpecialValueMap: &dashboard.SpecialValueMap{
+						Type: dashboard.MappingTypeSpecialValue,
+						Options: dashboard.DashboardSpecialValueMapOptions{
+							Match:  dashboard.SpecialValueMatchNull,
+							Result: dashboard.ValueMappingResult{Text: cog.ToPtr("N/A")},
+						},
+					}},
+				}),
+		).
+		WithPanel(etcdGeneralInfo("Keys", "short",
+			dashboard.GridPos{X: 12, Y: 12, W: 12, H: 8},
+			promQuery(`etcd_debugging_mvcc_keys_total{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod }} Num keys"),
+		)).
+		WithPanel(etcdGeneralInfo("Leader Elections Per Day", "short",
+			dashboard.GridPos{X: 0, Y: 12, W: 12, H: 6},
+			promQuery(`changes(etcd_server_leader_changes_seen_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[1d])`, "{{instance}} Total Leader Elections Per Day"),
+		)).
+		WithPanel(etcdGeneralInfo("Slow Operations", "ops",
+			dashboard.GridPos{X: 0, Y: 20, W: 12, H: 8},
+			promQuery(`delta(etcd_server_slow_apply_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "{{ pod }} slow applies"),
+			promQuery(`delta(etcd_server_slow_read_indexes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "{{ pod }} slow read indexes"),
+		)).
+		WithPanel(etcdGeneralInfo("Key Operations", "ops",
+			dashboard.GridPos{X: 12, Y: 20, W: 12, H: 8},
+			promQuery(`rate(etcd_mvcc_put_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "{{ pod }} puts/s"),
+			promQuery(`rate(etcd_mvcc_delete_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "{{ pod }} deletes/s"),
+		)).
+		WithPanel(etcdGeneralCounter("Heartbeat Failures", "short",
+			dashboard.GridPos{X: 0, Y: 28, W: 12, H: 8},
+			promQuery(`etcd_server_heartbeat_send_failures_total{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod }} heartbeat failures"),
+			promQuery(`etcd_server_health_failures{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod }} health failures"),
+		)).
+		WithPanel(etcdGeneralInfo("Compacted Keys", "short",
+			dashboard.GridPos{X: 12, Y: 28, W: 12, H: 8},
+			promQuery(`etcd_debugging_mvcc_db_compaction_keys_total{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod  }} keys compacted"),
+		))
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,7 @@
+module github.com/cloud-bulldozer/performance-dashboards
+
+go 1.21
+
+require github.com/grafana/grafana-foundation-sdk/go v0.0.0
+
+replace github.com/grafana/grafana-foundation-sdk/go => /Users/ancollin/go/src/github.com/grafana/grafana-foundation-sdk/go

--- a/go/go.mod
+++ b/go/go.mod
@@ -2,6 +2,7 @@ module github.com/cloud-bulldozer/performance-dashboards
 
 go 1.21
 
-require github.com/grafana/grafana-foundation-sdk/go v0.0.0
-
-replace github.com/grafana/grafana-foundation-sdk/go => /Users/ancollin/go/src/github.com/grafana/grafana-foundation-sdk/go
+require (
+	github.com/google/uuid v1.6.0
+	github.com/grafana/grafana-foundation-sdk/go v0.0.12
+)

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,4 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/grafana/grafana-foundation-sdk/go v0.0.12 h1:ggGWIJ3ylX16/xtAYlVi1TtUdv+mybYPusOmi1x35kg=
+github.com/grafana/grafana-foundation-sdk/go v0.0.12/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=

--- a/go/helpers.go
+++ b/go/helpers.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/elasticsearch"
+)
+
+func esDatasourceRef() common.DataSourceRef {
+	return common.DataSourceRef{
+		Type: cog.ToPtr("elasticsearch"),
+		Uid:  cog.ToPtr("${Datasource}"),
+	}
+}
+
+func dateHistogramBucketAgg(timeField, id string) elasticsearch.BucketAggregation {
+	dh, _ := elasticsearch.NewDateHistogramBuilder().
+		Field(timeField).
+		Id(id).
+		Settings(elasticsearch.NewElasticsearchDateHistogramSettingsBuilder().
+			Interval("auto").
+			MinDocCount("0").
+			TimeZone("utc"),
+		).
+		Build()
+	return elasticsearch.BucketAggregation{DateHistogram: &dh}
+}
+
+func termsBucketAgg(field, id string) elasticsearch.BucketAggregation {
+	t, _ := elasticsearch.NewTermsBuilder().
+		Field(field).
+		Id(id).
+		Settings(elasticsearch.NewElasticsearchTermsSettingsBuilder().
+			Order(elasticsearch.TermsOrderDesc).
+			OrderBy("_term").
+			MinDocCount("1").
+			Size("10"),
+		).
+		Build()
+	return elasticsearch.BucketAggregation{Terms: &t}
+}
+
+func avgMetric(field, id string) elasticsearch.MetricAggregation {
+	avg, _ := elasticsearch.NewAverageBuilder().
+		Field(field).
+		Id(id).
+		Build()
+	return elasticsearch.MetricAggregation{Average: &avg}
+}
+
+func avgMetricWithScript(field, id, script string) elasticsearch.MetricAggregation {
+	avg, _ := elasticsearch.NewAverageBuilder().
+		Field(field).
+		Id(id).
+		Settings(elasticsearch.NewElasticsearchAverageSettingsBuilder().
+			Script(elasticsearch.InlineScript{
+				ElasticsearchInlineScript: &elasticsearch.ElasticsearchInlineScript{
+					Inline: cog.ToPtr(script),
+				},
+			}),
+		).
+		Build()
+	return elasticsearch.MetricAggregation{Average: &avg}
+}
+
+func sumMetric(field, id string) elasticsearch.MetricAggregation {
+	s, _ := elasticsearch.NewSumBuilder().
+		Field(field).
+		Id(id).
+		Build()
+	return elasticsearch.MetricAggregation{Sum: &s}
+}
+
+func sumMetricWithScript(field, id, script string) elasticsearch.MetricAggregation {
+	s, _ := elasticsearch.NewSumBuilder().
+		Field(field).
+		Id(id).
+		Settings(elasticsearch.NewElasticsearchSumSettingsBuilder().
+			Script(elasticsearch.InlineScript{
+				ElasticsearchInlineScript: &elasticsearch.ElasticsearchInlineScript{
+					Inline: cog.ToPtr(script),
+				},
+			}),
+		).
+		Build()
+	return elasticsearch.MetricAggregation{Sum: &s}
+}
+
+func countMetric(id string) elasticsearch.MetricAggregation {
+	c, _ := elasticsearch.NewCountBuilder().
+		Id(id).
+		Build()
+	return elasticsearch.MetricAggregation{Count: &c}
+}

--- a/go/helpers.go
+++ b/go/helpers.go
@@ -6,6 +6,10 @@ import (
 	"github.com/grafana/grafana-foundation-sdk/go/elasticsearch"
 )
 
+func boolPtr(v bool) common.BoolOrFloat64 {
+	return common.BoolOrFloat64{Bool: cog.ToPtr(v)}
+}
+
 func esDatasourceRef() common.DataSourceRef {
 	return common.DataSourceRef{
 		Type: cog.ToPtr("elasticsearch"),

--- a/go/main.go
+++ b/go/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+)
+
+type dashboardDef struct {
+	name     string
+	category string
+	builder  func() *dashboard.DashboardBuilder
+}
+
+var dashboards = []dashboardDef{
+	{"vegeta-wrapper", "General", buildVegetaDashboard},
+}
+
+func main() {
+	outputDir := "rendered"
+
+	for _, d := range dashboards {
+		built, err := d.builder().Build()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error building dashboard %s/%s: %v\n", d.category, d.name, err)
+			os.Exit(1)
+		}
+
+		jsonBytes, err := json.MarshalIndent(built, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error marshaling dashboard %s/%s: %v\n", d.category, d.name, err)
+			os.Exit(1)
+		}
+
+		dir := filepath.Join(outputDir, d.category)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "error creating directory %s: %v\n", dir, err)
+			os.Exit(1)
+		}
+
+		outPath := filepath.Join(dir, d.name+".json")
+		if err := os.WriteFile(outPath, jsonBytes, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "error writing %s: %v\n", outPath, err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("wrote %s\n", outPath)
+	}
+}

--- a/go/main.go
+++ b/go/main.go
@@ -40,21 +40,20 @@ func main() {
 	loopInterval := flag.Duration("loop-interval", 60*time.Second, "Interval between deploy loops")
 	grafanaURL := flag.String("grafana-url", envDefault("GRAFANA_URL", ""), "Grafana URL (e.g. http://admin:pass@localhost:3000)")
 	inputDir := flag.String("input-dir", envDefault("INPUT_DIR", ""), "Directory with pre-rendered JSON (skips rendering)")
+	outputDir := flag.String("output-dir", envDefault("OUTPUT_DIR", "rendered"), "Directory to write rendered dashboard JSON")
 	gitCommitHash := flag.String("git-commit-hash", envDefault("GIT_COMMIT_HASH", ""), "Git commit hash to append to dashboard tags")
 	flag.Parse()
 
-	renderDir := "rendered"
-
 	// If --input-dir is set, skip rendering and deploy from that directory
 	if *inputDir == "" {
-		renderDashboards(renderDir)
+		renderDashboards(*outputDir)
 	}
 
 	if !*deployFlag {
 		return
 	}
 
-	deployDir := renderDir
+	deployDir := *outputDir
 	if *inputDir != "" {
 		deployDir = *inputDir
 	}
@@ -68,13 +67,15 @@ func main() {
 
 	for {
 		if err := d.deploy(); err != nil {
+			if !*loopFlag {
+				log.Fatalf("deploy error: %v", err)
+			}
 			log.Printf("deploy error: %v", err)
 		} else {
 			log.Println("deploy complete")
-		}
-
-		if !*loopFlag {
-			break
+			if !*loopFlag {
+				break
+			}
 		}
 		log.Printf("sleeping %s before next sync...", *loopInterval)
 		time.Sleep(*loopInterval)

--- a/go/main.go
+++ b/go/main.go
@@ -20,6 +20,8 @@ var dashboards = []dashboardDef{
 	{"uperf-perf", "General", buildUperfDashboard},
 	{"ocp-performance", "General", buildOCPPerformanceDashboard},
 	{"etcd-on-cluster-dashboard", "General", buildEtcdDashboard},
+	{"ovn-dashboard", "General", buildOVNDashboard},
+	{"api-performance-overview", "General", buildAPIPerformanceDashboard},
 }
 
 func main() {

--- a/go/main.go
+++ b/go/main.go
@@ -17,6 +17,7 @@ type dashboardDef struct {
 
 var dashboards = []dashboardDef{
 	{"vegeta-wrapper", "General", buildVegetaDashboard},
+	{"uperf-perf", "General", buildUperfDashboard},
 }
 
 func main() {

--- a/go/main.go
+++ b/go/main.go
@@ -19,6 +19,7 @@ var dashboards = []dashboardDef{
 	{"vegeta-wrapper", "General", buildVegetaDashboard},
 	{"uperf-perf", "General", buildUperfDashboard},
 	{"ocp-performance", "General", buildOCPPerformanceDashboard},
+	{"etcd-on-cluster-dashboard", "General", buildEtcdDashboard},
 }
 
 func main() {

--- a/go/main.go
+++ b/go/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
 )
@@ -24,9 +27,61 @@ var dashboards = []dashboardDef{
 	{"api-performance-overview", "General", buildAPIPerformanceDashboard},
 }
 
-func main() {
-	outputDir := "rendered"
+func envDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
 
+func main() {
+	deployFlag := flag.Bool("deploy", false, "Deploy rendered dashboards to Grafana")
+	loopFlag := flag.Bool("loop", false, "Run deploy in a loop (sidecar mode)")
+	loopInterval := flag.Duration("loop-interval", 60*time.Second, "Interval between deploy loops")
+	grafanaURL := flag.String("grafana-url", envDefault("GRAFANA_URL", ""), "Grafana URL (e.g. http://admin:pass@localhost:3000)")
+	inputDir := flag.String("input-dir", envDefault("INPUT_DIR", ""), "Directory with pre-rendered JSON (skips rendering)")
+	gitCommitHash := flag.String("git-commit-hash", envDefault("GIT_COMMIT_HASH", ""), "Git commit hash to append to dashboard tags")
+	flag.Parse()
+
+	renderDir := "rendered"
+
+	// If --input-dir is set, skip rendering and deploy from that directory
+	if *inputDir == "" {
+		renderDashboards(renderDir)
+	}
+
+	if !*deployFlag {
+		return
+	}
+
+	deployDir := renderDir
+	if *inputDir != "" {
+		deployDir = *inputDir
+	}
+
+	if *grafanaURL == "" {
+		fmt.Fprintln(os.Stderr, "error: --grafana-url or GRAFANA_URL is required for deploy")
+		os.Exit(1)
+	}
+
+	d := newDeployer(*grafanaURL, deployDir, *gitCommitHash)
+
+	for {
+		if err := d.deploy(); err != nil {
+			log.Printf("deploy error: %v", err)
+		} else {
+			log.Println("deploy complete")
+		}
+
+		if !*loopFlag {
+			break
+		}
+		log.Printf("sleeping %s before next sync...", *loopInterval)
+		time.Sleep(*loopInterval)
+	}
+}
+
+func renderDashboards(outputDir string) {
 	for _, d := range dashboards {
 		built, err := d.builder().Build()
 		if err != nil {

--- a/go/main.go
+++ b/go/main.go
@@ -18,6 +18,7 @@ type dashboardDef struct {
 var dashboards = []dashboardDef{
 	{"vegeta-wrapper", "General", buildVegetaDashboard},
 	{"uperf-perf", "General", buildUperfDashboard},
+	{"ocp-performance", "General", buildOCPPerformanceDashboard},
 }
 
 func main() {

--- a/go/main.go
+++ b/go/main.go
@@ -25,6 +25,7 @@ var dashboards = []dashboardDef{
 	{"etcd-on-cluster-dashboard", "General", buildEtcdDashboard},
 	{"ovn-dashboard", "General", buildOVNDashboard},
 	{"api-performance-overview", "General", buildAPIPerformanceDashboard},
+	{"node", "General", buildNodeDashboard},
 }
 
 func envDefault(key, fallback string) string {

--- a/go/node.go
+++ b/go/node.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+)
+
+func buildNodeDashboard() *dashboard.DashboardBuilder {
+	return dashboard.NewDashboardBuilder("Node Performance").
+		Description("Node Performance dashboard for Red Hat Openshift\n").
+		Tags([]string{}).
+		Time("now-1h", "now").
+		Timezone("utc").
+		Timepicker(dashboard.NewTimePickerBuilder().
+			RefreshIntervals([]string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}),
+		).
+		Refresh("").
+		Tooltip(dashboard.DashboardCursorSyncCrosshair).
+		WithVariable(dashboard.NewDatasourceVariableBuilder("Datasource").
+			Type("prometheus").
+			Label("Datasource"),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("namespace").
+			Label("Namespace").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(kube_pod_info{namespace!="(cluster-density.*|node-density-.*)"},namespace)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Regex("").
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewIntervalVariableBuilder("interval").
+			Label("interval").
+			Values(dashboard.StringOrMap{String: cog.ToPtr("5m,2m,1m")}).
+			Current(intervalOption("5m")).
+			Options([]dashboard.VariableOption{
+				intervalOption("5m"),
+				intervalOption("2m"),
+				intervalOption("1m"),
+			}),
+		).
+		WithRow(nodeResourceRow()).
+		WithRow(nodeCgroupResourceRow()).
+		WithRow(nodeClusterWorkloadRow()).
+		WithRow(nodeTopUsageRow()).
+		WithRow(nodeKubeletOperationRow()).
+		WithRow(nodeP99KubeletCgroupRow()).
+		WithRow(nodeKubeletResourceUsageRow()).
+		WithRow(nodeKubeletHTTPRow()).
+		WithRow(nodeCRIOOperationRow()).
+		WithRow(nodeCRIOResourceUsageRow()).
+		WithRow(nodeINodesRow()).
+		WithRow(nodePLEGRow()).
+		WithRow(nodePSIContainersRow()).
+		WithRow(nodePSINodesRow())
+}
+
+func nodeResourceRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Node Resource").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendTimeSeries("Workers CPU Usage", "percent",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`sum( rate( (node_cpu_seconds_total{ mode != "idle" } * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)") )[$interval:] ) ) by (instance) * 100`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Control Plane CPU Usage", "percent",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`sum( rate( (node_cpu_seconds_total{ mode != "idle" } * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)") )[$interval:] ) ) by (instance) * 100`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Workers Load1", "short",
+			dashboard.GridPos{X: 0, Y: 9, W: 12, H: 8},
+			promQuery(`node_load1 * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)") `, "{{instance}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Control Plane Load1", "short",
+			dashboard.GridPos{X: 12, Y: 9, W: 12, H: 8},
+			promQuery(`node_load1 * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)") `, "{{instance}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Workers Memory Available", "bytes",
+			dashboard.GridPos{X: 0, Y: 17, W: 12, H: 8},
+			promQuery(`node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)")`, "{{instance}}"),
+			promQuery(`sum( node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)") )`, "sum"),
+		)).
+		WithPanel(genericLegendTimeSeries("Control Plane Memory Available", "bytes",
+			dashboard.GridPos{X: 12, Y: 17, W: 12, H: 8},
+			promQuery(`node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)")`, "{{instance}}"),
+			promQuery(`sum( node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)") )`, "sum"),
+		)).
+		WithPanel(genericLegendTimeSeries("Workers Disk IOPS", "short",
+			dashboard.GridPos{X: 0, Y: 25, W: 12, H: 8},
+			promQuery(`rate( (  node_disk_reads_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "worker" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - read"),
+			promQuery(`rate( (  node_disk_writes_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "worker" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - write"),
+		)).
+		WithPanel(genericLegendTimeSeries("Control Plane Disk IOPS", "short",
+			dashboard.GridPos{X: 12, Y: 25, W: 12, H: 8},
+			promQuery(`rate( (  node_disk_reads_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "control-plane" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - read"),
+			promQuery(`rate( (  node_disk_writes_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "control-plane" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - write"),
+		)).
+		WithPanel(genericLegendCounterTimeSeries("Workers Container Threads", "short",
+			dashboard.GridPos{X: 0, Y: 33, W: 12, H: 8},
+			promQuery(`sum by (node) (container_threads{ container!=""})  * on (node) group_left kube_node_role{ role = "worker" }`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendCounterTimeSeries("Control Plane Container Threads", "short",
+			dashboard.GridPos{X: 12, Y: 33, W: 12, H: 8},
+			promQuery(`sum by (node) (container_threads{ container!=""})  * on (node) group_left kube_node_role{ role = "control-plane" }`, "{{instance}}"),
+		))
+}
+
+func nodeCgroupResourceRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Cgroup Resource").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendTimeSeries("Workers CGroup CPU(% of 1 core)", "short",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`sum by (id) (( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/system.slice/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) * 100 * on (node) group_left kube_node_role{ role = "worker" } )`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Control Plane CGroup CPU(% of 1 core)", "short",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`sum by (id) (( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/system.slice/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) * 100 * on (node) group_left kube_node_role{ role = "control-plane" } )`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendCounterTimeSeries("Workers CGroup Memory Working Set", "bytes",
+			dashboard.GridPos{X: 0, Y: 10, W: 12, H: 8},
+			promQuery(`sum by (id) (container_memory_working_set_bytes{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/system.slice/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"} * on (node) group_left kube_node_role{ role = "worker" } )`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendCounterTimeSeries("Control Plane CGroup Memory Working Set", "bytes",
+			dashboard.GridPos{X: 12, Y: 10, W: 12, H: 8},
+			promQuery(`sum by (id) (container_memory_working_set_bytes{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/system.slice/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"} * on (node) group_left kube_node_role{ role = "control-plane" } )`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("system.slice Working Set by node", "bytes",
+			dashboard.GridPos{X: 0, Y: 18, W: 12, H: 8},
+			promQuery(`sum by (node)(container_memory_working_set_bytes{id="/system.slice"})`, "system.slice - {{ node }}"),
+		)).
+		WithPanel(genericLegendTimeSeries("system.slice CPU by node", "bytes",
+			dashboard.GridPos{X: 12, Y: 18, W: 12, H: 8},
+			promQuery(`sum by (node) (( rate(container_cpu_usage_seconds_total{id="/system.slice"}[$interval])) * 100)`, "system.slice - {{ node }}"),
+		))
+}
+
+func nodeClusterWorkloadRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Cluster Workload").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericTimeSeries("Pod count", "none",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`sum(kube_pod_status_phase{}) by (phase)`, "{{phase}} pods"),
+		)).
+		WithPanel(genericLegendTimeSeries("Pod Distribution", "none",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`count(kube_pod_info{}) by (node)`, "{{ node }}"),
+		)).
+		WithPanel(genericTimeSeries("Container count", "none",
+			dashboard.GridPos{X: 0, Y: 10, W: 12, H: 8},
+			promQuery(`count(kube_pod_container_info)`, "Containers"),
+		)).
+		WithPanel(genericLegendTimeSeries("Container Distribution", "none",
+			dashboard.GridPos{X: 12, Y: 10, W: 12, H: 8},
+			promQuery(`count(container_last_seen{}) by (node)`, "Containers on {{node}}"),
+		))
+}
+
+func nodeTopUsageRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Top Usage").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendTimeSeries("Top 10 Container Memory Working Set", "bytes",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`topk(10, container_memory_working_set_bytes{namespace!="",container!="POD",name!=""})`, "{{ namespace }} - {{ name }}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Top 10 Container CPU(% of 1 core)", "percent",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`topk(10,irate(container_cpu_usage_seconds_total{namespace!="",container!="POD",name!=""}[$interval])*100)`, "{{ namespace }} - {{ name }}"),
+		)).
+		WithPanel(genericTimeSeries("Top 10 Goroutines count", "none",
+			dashboard.GridPos{X: 0, Y: 10, W: 12, H: 8},
+			promQuery(`topk(10, sum(go_goroutines{}) by (job,instance))`, "{{ job }} - {{ instance }}"),
+		))
+}
+
+func nodeKubeletOperationRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Kubelet Operation").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendCounterTimeSeries("Workers Kubelet Runtime Operations Errors/second, >0.001 Waning, >0.01 Critical, >0.1 Severe", "short",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`sum by (node, operation_type) (rate(kubelet_runtime_operations_errors_total [$interval])  *  on (node) group_left kube_node_role{ role = "worker" })`, "{{node}}: {{operation_type}}"),
+		)).
+		WithPanel(genericLegendCounterTimeSeries("Control Plane Kubelet Runtime Operations Errors/second, >0.001 Waning, >0.01 Critical, >0.1 Severe", "short",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`sum by (node, operation_type) (rate(kubelet_runtime_operations_errors_total [$interval]) *  on (node) group_left kube_node_role{ role = "control-plane" })`, "{{node}}: {{operation_type}}"),
+		))
+}
+
+func nodeP99KubeletCgroupRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("P99 Kubelet Croup Manager Duration").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendCounterTimeSeries("P99 Kubelet Croup Manager Duration - Create", "short",
+			dashboard.GridPos{X: 0, Y: 2, W: 8, H: 8},
+			promQuery(`sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{node=~".*",operation_type="create"}[5m])) by (node, operation_type, le)`, "{{node}}: {{operation_type}}"),
+		)).
+		WithPanel(genericLegendCounterTimeSeries("p99KubeletCroupManagerDuration - Update", "short",
+			dashboard.GridPos{X: 8, Y: 2, W: 8, H: 8},
+			promQuery(`sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{node=~".*",operation_type="update"}[5m])) by (node, operation_type, le)`, "{{node}}: {{operation_type}}"),
+		)).
+		WithPanel(genericLegendCounterTimeSeries("p99KubeletCroupManagerDuration - Destroy", "short",
+			dashboard.GridPos{X: 16, Y: 2, W: 8, H: 8},
+			promQuery(`sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{node=~".*",operation_type="destroy"}[5m])) by (node, operation_type, le)`, "{{node}}: {{operation_type}}"),
+		))
+}
+
+func nodeKubeletResourceUsageRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Kubelet Resource Usage").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendTimeSeries("Top 10 Kubelet Process CPU Usage(% of 1 core)", "percent",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`topk(10,irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[$interval])*100 *  on (node) group_left kube_node_role{ role = "worker" })`, "kubelet - {{node}}"),
+		)).
+		WithPanel(genericLegendCounterTimeSeries("Top 10 Kubelet Process Resident Memory", "bytes",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`topk(10,process_resident_memory_bytes{service="kubelet",job="kubelet"} *  on (node) group_left kube_node_role{ role = "worker" })`, "kubelet - {{node}}"),
+		))
+}
+
+func nodeKubeletHTTPRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Kubelet HTTP requests Performance").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendTimeSeries("Kubelet HTTP requests count by path", "none",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`sum(rate(kubelet_http_requests_duration_seconds_count[$interval])) by (path)`, "{{ path }}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Kubelet HTTP requests count by node", "none",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`sum(rate(kubelet_http_requests_duration_seconds_count[$interval])) by (node)`, "{{ node }}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Kubelet HTTP requests latency per request by path (ms)", "none",
+			dashboard.GridPos{X: 0, Y: 10, W: 12, H: 8},
+			promQuery(`sum(rate(kubelet_http_requests_duration_seconds_sum[$interval])) by (path) * 1000/sum(rate(kubelet_http_requests_duration_seconds_count[$interval])) by (path)`, "{{ path }}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Kubelet HTTP requests latency per request by node (ms)> 200ms Warning, > 500ms Critical", "none",
+			dashboard.GridPos{X: 12, Y: 10, W: 12, H: 8},
+			promQuery(`sum(rate(kubelet_http_requests_duration_seconds_sum[$interval])) by (node) * 1000/sum(rate(kubelet_http_requests_duration_seconds_count[$interval])) by (node)`, "{{ node }}"),
+		))
+}
+
+func nodeCRIOOperationRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("CRIO Operation").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendCounterTimeSeries("Workers Runtime Crio Operations Errors/second, > 0.001 Warning, >0.01 Critical", "short",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`sum by (node, operation) (rate(container_runtime_crio_operations_errors_total [$interval])  *  on (node) group_left kube_node_role{ role = "worker" })`, "{{node}}: {{ operation }}"),
+		)).
+		WithPanel(genericLegendCounterTimeSeries("Control Plane Runtime Crio Operations Errors/second, > 0.001 Warning, >0.01 Critical", "short",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`sum by (node, operation) (rate(container_runtime_crio_operations_errors_total [$interval]) *  on (node) group_left kube_node_role{ role = "control-plane" })`, "{{node}}: {{ operation }}"),
+		)).
+		WithPanel(genericLegendCounterTimeSeries("Workers Runtime Crio Operations Latency Avg(second), > 1s Warning, >5s Critical", "short",
+			dashboard.GridPos{X: 0, Y: 10, W: 12, H: 8},
+			promQuery(`topk(10, sum by (operation, node) (rate(container_runtime_crio_operations_latency_seconds_total[$interval]))/sum by (operation, node) (rate(container_runtime_crio_operations_total[$interval])) * on (node) group_left kube_node_role{ role = "worker" } * 100)`, "{{node}}: {{ operation }}"),
+		)).
+		WithPanel(genericLegendCounterTimeSeries("Control Plane Runtime Crio Operations Latency Avg(second), > 1s Warning, >5s Critical", "short",
+			dashboard.GridPos{X: 12, Y: 10, W: 12, H: 8},
+			promQuery(`topk(10, sum by (operation, node) (rate(container_runtime_crio_operations_latency_seconds_total[$interval]))/sum by (operation, node) (rate(container_runtime_crio_operations_total[$interval])) * on (node) group_left kube_node_role{ role = "control-plane" } * 100)`, "{{node}}: {{ operation }}"),
+		))
+}
+
+func nodeCRIOResourceUsageRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("CRIO Resource Usage").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendTimeSeries("Top 10 crio Process CPU Usage(% of 1 core)", "percent",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`topk(10,irate(process_cpu_seconds_total{service="kubelet",job="crio"}[$interval])*100 *  on (node) group_left kube_node_role{ role = "worker" })`, "crio - {{node}}"),
+		)).
+		WithPanel(genericLegendCounterTimeSeries("Top 10 crio Process Resident Memory", "bytes",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`topk(10,process_resident_memory_bytes{service="kubelet",job="crio"} *  on (node) group_left kube_node_role{ role = "worker" })`, "crio - {{node}}"),
+		))
+}
+
+func nodeINodesRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("iNodes Usage").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendTimeSeries("inodes usage in /run", "percent",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`(1 - node_filesystem_files_free{fstype!="",mountpoint="/run"} / node_filesystem_files{fstype!="",mountpoint="/run"}) * 100`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("inodes count in /run", "none",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`node_filesystem_files{fstype!="",mountpoint="/run"} - node_filesystem_files_free{fstype!="",mountpoint="/run"}`, "{{instance}}"),
+			promQuery(`sum(node_filesystem_files{fstype!="",mountpoint="/run"} - node_filesystem_files_free{fstype!="",mountpoint="/run"})`, "sum"),
+		))
+}
+
+func nodePLEGRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Pod Lifecycle Event Generator (PLEG)").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendTimeSeries("P95 PLEG Latency (s), >1s Waning, >3s Critical", "short",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`histogram_quantile(0.95, sum(rate(kubelet_pleg_relist_duration_seconds_bucket [$interval])) by (node, le))`, "{{node}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("P95 PLEG Latency (s), >3s Waning, >5s Critical", "short",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket [$interval])) by (node, le))`, "{{node}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Average Latency  (s), >0.5s Waning, >1s Critical", "short",
+			dashboard.GridPos{X: 0, Y: 10, W: 12, H: 8},
+			promQuery(`rate(kubelet_pleg_relist_duration_seconds_sum [$interval])/rate(kubelet_pleg_relist_duration_seconds_count[$interval])`, "{{node}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("PLEG Relist Count in 5 mins, <150 Waning, <50 Critical", "short",
+			dashboard.GridPos{X: 12, Y: 10, W: 12, H: 8},
+			promQuery(`sum(increase(kubelet_pleg_relist_duration_seconds_count[5m])) by (node)`, "{{node}}"),
+		))
+}
+
+func nodePSIContainersRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("PSI - Containers (need to enable PSI)").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendTimeSeries("Top 10 Container Pressure Memory Stalled, >1% Waning, >5% Critical", "percent",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`topk(10, sum(rate(container_pressure_memory_stalled_seconds_total{container!="POD",name!="",namespace!="",namespace=~"$namespace"}[$interval])) by (node,pod,container,namespace,name,service) * 100)`, "{{node}}: {{ pod }}: {{ container }}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Top 10 Container Pressure Memory Waiting, >5% Waning, >10% Critical", "percent",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`topk(10, sum(rate(container_pressure_memory_waiting_seconds_total{container!="POD",name!="",namespace!="",namespace=~"$namespace"}[$interval])) by (node,pod,container,namespace,name,service) * 100)`, "{{node}}: {{ pod }}: {{ container }}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Top 10 Container Pressure CPU Stalled, >1% Waning, >5% Critical", "percent",
+			dashboard.GridPos{X: 0, Y: 10, W: 12, H: 8},
+			promQuery(`topk(10, sum(irate(container_pressure_cpu_stalled_seconds_total{container!="POD",name!="",namespace!="",namespace=~"$namespace"}[$interval])) by (node,pod,container,namespace,name,service) * 100)`, "{{node}}: {{ pod }}: {{ container }}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Top 10 Container Pressure CPU Waiting, >20% Waning, >50% Critical", "percent",
+			dashboard.GridPos{X: 12, Y: 10, W: 12, H: 8},
+			promQuery(`topk(10, sum(rate(container_pressure_cpu_waiting_seconds_total{container!="POD",name!="",namespace!="",namespace=~"$namespace"}[$interval])) by (node,pod,container,namespace,name,service) * 100)`, "{{node}}: {{ pod }}: {{ container }}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Top 10 Container Pressure IO Stalled, >5% Waning, >10% Critical", "percent",
+			dashboard.GridPos{X: 0, Y: 18, W: 12, H: 8},
+			promQuery(`topk(10, sum(rate(container_pressure_io_stalled_seconds_total{container!="POD",name!="",namespace!="",namespace=~"$namespace"}[$interval])) by (node,pod,container,namespace,name,service) * 100)`, "{{node}}: {{ pod }}: {{ container }}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Top 10 Container Pressure IO Waiting, >10% Waning, >30% Critical", "percent",
+			dashboard.GridPos{X: 12, Y: 18, W: 12, H: 8},
+			promQuery(`topk(10, sum(rate(container_pressure_io_waiting_seconds_total{container!="POD",name!="",namespace!="",namespace=~"$namespace"}[$interval])) by (node,pod,container,namespace,name,service) * 100)`, "{{node}}: {{ pod }}: {{ container }}"),
+		))
+}
+
+func nodePSINodesRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("PSI - Nodes (need to enable PSI)").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(genericLegendTimeSeries("Top 10 Node Pressure Memory Stalled, >1% Waning, >5% Critical", "percent",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`topk(10, rate(node_pressure_memory_stalled_seconds_total [$interval]) * 100)`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Top 10 Node Pressure Memory Waiting, >10% Waning, >30% Critical", "percent",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`topk(10, rate(node_pressure_memory_waiting_seconds_total [$interval]) * 100)`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Top 10 Node Pressure IO Stalled, >10% Waning, >30% Critical", "percent",
+			dashboard.GridPos{X: 0, Y: 10, W: 12, H: 8},
+			promQuery(`topk(10, rate(node_pressure_io_stalled_seconds_total [$interval]) * 100)`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Top 10 Node Pressure IO Waiting, >30% Waning, >60% Critical", "percent",
+			dashboard.GridPos{X: 12, Y: 10, W: 12, H: 8},
+			promQuery(`topk(10, rate(node_pressure_io_waiting_seconds_total[$interval]) * 100)`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Top 10 Node Pressure CPU Waiting, >5% Waning, >20% Critical", "percent",
+			dashboard.GridPos{X: 0, Y: 18, W: 12, H: 8},
+			promQuery(`topk(10, rate(node_pressure_cpu_waiting_seconds_total [$interval]) * 100)`, "{{instance}}"),
+		)).
+		WithPanel(genericLegendTimeSeries("Top 10 Node Pressure IRQ Stalled, >5% Waning, >10% Critical", "percent",
+			dashboard.GridPos{X: 12, Y: 18, W: 12, H: 8},
+			promQuery(`topk(10, rate(node_pressure_irq_stalled_seconds_total [$interval]) * 100)`, "{{instance}}"),
+		))
+}

--- a/go/ocp_performance.go
+++ b/go/ocp_performance.go
@@ -92,8 +92,6 @@ func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
 		WithRow(ocpOVNRow()).
 		// Row: Monitoring stack
 		WithRow(ocpMonitoringStackRow()).
-		// Row: Stackrox
-		WithRow(ocpStackroxRow()).
 		// Row: Cluster Kubelet
 		WithRow(ocpClusterKubeletRow()).
 		// Row: Cluster Details
@@ -105,7 +103,9 @@ func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
 		// Row: Worker
 		WithRow(ocpWorkerRow()).
 		// Row: Infra
-		WithRow(ocpInfraRow())
+		WithRow(ocpInfraRow()).
+		// Row: Stackrox
+		WithRow(ocpStackroxRow())
 }
 
 func intervalOption(val string) dashboard.VariableOption {

--- a/go/ocp_performance.go
+++ b/go/ocp_performance.go
@@ -301,11 +301,11 @@ func ocpOVNRow() *dashboard.RowBuilder {
 		Collapsed(true).
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
 		WithPanel(ocpGenericLegend("Top 10 ovnkube-controller CPU Usage", "percent",
-			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 8},
+			dashboard.GridPos{X: 0, Y: 1, W: 12, H: 8},
 			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovnkube-controller"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(ocpGenericLegend("Top 10 ovnkube-controller Memory Usage", "bytes",
-			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 8},
+			dashboard.GridPos{X: 12, Y: 1, W: 12, H: 8},
 			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="ovnkube-controller"}) by (pod,node))`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(ocpGenericLegend("Top 10 ovn-controller CPU Usage", "percent",
@@ -556,11 +556,11 @@ func ocpMasterRow() *dashboard.RowBuilder {
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 8}).
 		Repeat("_master_node").
 		WithPanel(ocpGenericLegend("CPU Basic: $_master_node", "percent",
-			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 8},
+			dashboard.GridPos{X: 0, Y: 1, W: 12, H: 8},
 			promQuery(`sum by (instance, mode)(irate(node_cpu_seconds_total{instance=~"$_master_node",job=~".*"}[$interval])) * 100`, "Busy {{mode}}"),
 		)).
 		WithPanel(ocpGenericLegendCounter("System Memory: $_master_node", "bytes",
-			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 8},
+			dashboard.GridPos{X: 12, Y: 1, W: 12, H: 8},
 			promQuery(`node_memory_Active_bytes{instance=~"$_master_node"}`, "Active"),
 			promQuery(`node_memory_MemTotal_bytes{instance=~"$_master_node"}`, "Total"),
 			promQuery(`node_memory_Cached_bytes{instance=~"$_master_node"} + node_memory_Buffers_bytes{instance=~"$_master_node"}`, "Cached + Buffers"),
@@ -632,11 +632,11 @@ func ocpWorkerRow() *dashboard.RowBuilder {
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 8}).
 		Repeat("_worker_node").
 		WithPanel(ocpGenericLegend("CPU Basic: $_worker_node", "percent",
-			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 8},
+			dashboard.GridPos{X: 0, Y: 1, W: 12, H: 8},
 			promQuery(`sum by (instance, mode)(irate(node_cpu_seconds_total{instance=~"$_worker_node",job=~".*"}[$interval])) * 100`, "Busy {{mode}}"),
 		)).
 		WithPanel(ocpGenericLegendCounter("System Memory: $_worker_node", "bytes",
-			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 8},
+			dashboard.GridPos{X: 12, Y: 1, W: 12, H: 8},
 			promQuery(`node_memory_Active_bytes{instance=~"$_worker_node"}`, "Active"),
 			promQuery(`node_memory_MemTotal_bytes{instance=~"$_worker_node"}`, "Total"),
 			promQuery(`node_memory_Cached_bytes{instance=~"$_worker_node"} + node_memory_Buffers_bytes{instance=~"$_worker_node"}`, "Cached + Buffers"),
@@ -698,11 +698,11 @@ func ocpInfraRow() *dashboard.RowBuilder {
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 8}).
 		Repeat("_infra_node").
 		WithPanel(ocpGenericLegend("CPU Basic: $_infra_node", "percent",
-			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 8},
+			dashboard.GridPos{X: 0, Y: 1, W: 12, H: 8},
 			promQuery(`sum by (instance, mode)(irate(node_cpu_seconds_total{instance=~"$_infra_node",job=~".*"}[$interval])) * 100`, "Busy {{mode}}"),
 		)).
 		WithPanel(ocpGenericLegend("System Memory: $_infra_node", "bytes",
-			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 8},
+			dashboard.GridPos{X: 12, Y: 1, W: 12, H: 8},
 			promQuery(`node_memory_Active_bytes{instance=~"$_infra_node"}`, "Active"),
 			promQuery(`node_memory_MemTotal_bytes{instance=~"$_infra_node"}`, "Total"),
 			promQuery(`node_memory_Cached_bytes{instance=~"$_infra_node"} + node_memory_Buffers_bytes{instance=~"$_infra_node"}`, "Cached + Buffers"),

--- a/go/ocp_performance.go
+++ b/go/ocp_performance.go
@@ -137,7 +137,7 @@ func ocpGeneric(title, unit string, gridPos dashboard.GridPos, targets ...*prome
 		Datasource(promDatasourceRef()).
 		Unit(unit).
 		GridPos(gridPos).
-		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr(false)}).
+		SpanNulls(boolPtr(false)).
 		Tooltip(common.NewVizTooltipOptionsBuilder().
 			Mode(common.TooltipDisplayModeMulti).
 			Sort(common.SortOrderDescending),
@@ -159,7 +159,7 @@ func ocpGenericLegend(title, unit string, gridPos dashboard.GridPos, targets ...
 		Datasource(promDatasourceRef()).
 		Unit(unit).
 		GridPos(gridPos).
-		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr(false)}).
+		SpanNulls(boolPtr(false)).
 		Tooltip(common.NewVizTooltipOptionsBuilder().
 			Mode(common.TooltipDisplayModeMulti).
 			Sort(common.SortOrderDescending),
@@ -185,7 +185,7 @@ func ocpGenericLegendCounter(title, unit string, gridPos dashboard.GridPos, targ
 		Datasource(promDatasourceRef()).
 		Unit(unit).
 		GridPos(gridPos).
-		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr(false)}).
+		SpanNulls(boolPtr(false)).
 		Tooltip(common.NewVizTooltipOptionsBuilder().
 			Mode(common.TooltipDisplayModeMulti).
 			Sort(common.SortOrderDescending),

--- a/go/ocp_performance.go
+++ b/go/ocp_performance.go
@@ -1,0 +1,750 @@
+package main
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
+	"github.com/grafana/grafana-foundation-sdk/go/stat"
+	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
+)
+
+func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
+	return dashboard.NewDashboardBuilder("Openshift Performance").
+		Description("Performance dashboard for Red Hat Openshift\n").
+		Tags([]string{}).
+		Time("now-1h", "now").
+		Timezone("utc").
+		Timepicker(dashboard.NewTimePickerBuilder().
+			RefreshIntervals([]string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}),
+		).
+		Refresh("30s").
+		Tooltip(dashboard.DashboardCursorSyncCrosshair).
+		WithVariable(dashboard.NewDatasourceVariableBuilder("Datasource").
+			Type("prometheus").
+			Label("Datasource"),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("_master_node").
+			Label("Master").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(kube_node_role{role="master"}, node)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(true).
+			IncludeAll(false),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("_worker_node").
+			Label("Worker").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(kube_node_role{role=~"worker"}, node)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(true).
+			IncludeAll(false),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("_infra_node").
+			Label("Infra").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(kube_node_role{role="infra"}, node)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(true).
+			IncludeAll(false),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("namespace").
+			Label("Namespace").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(kube_pod_info{namespace!="(cluster-density.*|node-density-.*)"},namespace)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Regex("").
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("block_device").
+			Label("Block device").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(node_disk_written_bytes_total, device)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Regex(`/^(?:(?!dm|rb).)*$/`).
+			Multi(true).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("net_device").
+			Label("Network device").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(node_network_receive_bytes_total, device)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Regex(`/^((br|en|et).*)$/`).
+			Multi(true).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewIntervalVariableBuilder("interval").
+			Label("interval").
+			Values(dashboard.StringOrMap{String: cog.ToPtr("2m,3m,4m,5m")}).
+			Current(intervalOption("2m")).
+			Options([]dashboard.VariableOption{
+				intervalOption("2m"),
+				intervalOption("3m"),
+				intervalOption("4m"),
+				intervalOption("5m"),
+			}),
+		).
+		// Row: Cluster-at-a-Glance
+		WithRow(ocpClusterAtAGlanceRow()).
+		// Row: OVN
+		WithRow(ocpOVNRow()).
+		// Row: Monitoring stack
+		WithRow(ocpMonitoringStackRow()).
+		// Row: Stackrox
+		WithRow(ocpStackroxRow()).
+		// Row: Cluster Kubelet
+		WithRow(ocpClusterKubeletRow()).
+		// Row: Cluster Details
+		WithRow(ocpClusterDetailsRow()).
+		// Row: Cluster Operators Details
+		WithRow(ocpClusterOperatorsDetailsRow()).
+		// Row: Master
+		WithRow(ocpMasterRow()).
+		// Row: Worker
+		WithRow(ocpWorkerRow()).
+		// Row: Infra
+		WithRow(ocpInfraRow())
+}
+
+func intervalOption(val string) dashboard.VariableOption {
+	return dashboard.VariableOption{
+		Text:  dashboard.StringOrArrayOfString{String: &val},
+		Value: dashboard.StringOrArrayOfString{String: &val},
+	}
+}
+
+func promDatasourceRef() common.DataSourceRef {
+	return common.DataSourceRef{
+		Type: cog.ToPtr("prometheus"),
+		Uid:  cog.ToPtr("${Datasource}"),
+	}
+}
+
+func promQuery(expr, legend string) *prometheus.DataqueryBuilder {
+	return prometheus.NewDataqueryBuilder().
+		Expr(expr).
+		LegendFormat(legend).
+		Format(prometheus.PromQueryFormatTimeSeries).
+		IntervalFactor(2)
+}
+
+// Panel type: generic - base timeseries with tooltip multi/desc, legend table mode
+func ocpGeneric(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	p := timeseries.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr(false)}).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderDescending),
+		).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			DisplayMode(common.LegendDisplayModeTable),
+		)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}
+
+// Panel type: genericLegend - extends generic with calcs [mean, min, max], sortBy Max desc, placement bottom
+func ocpGenericLegend(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	p := timeseries.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr(false)}).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderDescending),
+		).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			DisplayMode(common.LegendDisplayModeTable).
+			Calcs([]string{"mean", "min", "max"}).
+			SortBy("Max").
+			SortDesc(true).
+			Placement(common.LegendPlacementBottom),
+		)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}
+
+// Panel type: genericLegendCounter - extends generic with calcs [first, min, max, last], sortBy Max desc, placement bottom
+func ocpGenericLegendCounter(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	p := timeseries.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr(false)}).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderDescending),
+		).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			DisplayMode(common.LegendDisplayModeTable).
+			Calcs([]string{"first", "min", "max", "last"}).
+			SortBy("Max").
+			SortDesc(true).
+			Placement(common.LegendPlacementBottom),
+		)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}
+
+// Panel type: genericLegendCounterSumRightHand - extends genericLegendCounter with override for 'sum' series on right axis
+func ocpGenericLegendCounterSumRightHand(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	p := ocpGenericLegendCounter(title, unit, gridPos, targets...)
+	return p.OverrideByRegexp("sum", []dashboard.DynamicConfigValue{
+		{Id: "custom.axisPlacement", Value: "right"},
+		{Id: "custom.axisLabel", Value: "sum"},
+	})
+}
+
+// Stat panel
+func ocpStat(title string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *stat.PanelBuilder {
+	p := stat.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		GridPos(gridPos).
+		ReduceOptions(common.NewReduceDataOptionsBuilder().
+			Calcs([]string{"last"}),
+		)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}
+
+// Row: Cluster-at-a-Glance
+func ocpClusterAtAGlanceRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Cluster-at-a-Glance").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(ocpGenericLegend("Workers CPU Usage", "percent",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`sum( rate( (node_cpu_seconds_total{ mode != "idle" } * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)") )[$interval:] ) ) by (instance) * 100`, "{{instance}}"),
+		)).
+		WithPanel(ocpGenericLegend("Control Plane CPU Usage", "percent",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`sum( rate( (node_cpu_seconds_total{ mode != "idle" } * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)") )[$interval:] ) ) by (instance) * 100`, "{{instance}}"),
+		)).
+		WithPanel(ocpGenericLegend("Workers Load1", "short",
+			dashboard.GridPos{X: 0, Y: 9, W: 12, H: 8},
+			promQuery(`node_load1 * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)") `, "{{instance}}"),
+		)).
+		WithPanel(ocpGenericLegend("Control Plane Load1", "short",
+			dashboard.GridPos{X: 12, Y: 9, W: 12, H: 8},
+			promQuery(`node_load1 * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)") `, "{{instance}}"),
+		)).
+		WithPanel(ocpGenericLegendCounterSumRightHand("Workers Memory Available", "bytes",
+			dashboard.GridPos{X: 0, Y: 17, W: 12, H: 8},
+			promQuery(`node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)")`, "{{instance}}"),
+			promQuery(`sum( node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)") )`, "sum"),
+		)).
+		WithPanel(ocpGenericLegendCounterSumRightHand("Control Plane Memory Available", "bytes",
+			dashboard.GridPos{X: 12, Y: 17, W: 12, H: 8},
+			promQuery(`node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)")`, "{{instance}}"),
+			promQuery(`sum( node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)") )`, "sum"),
+		)).
+		WithPanel(ocpGenericLegend("Workers CGroup CPU Rate", "percent",
+			dashboard.GridPos{X: 0, Y: 25, W: 12, H: 8},
+			promQuery(`sum by (id) (( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) * 100 * on (node) group_left kube_node_role{ role = "worker" } )`, "{{instance}}"),
+		)).
+		WithPanel(ocpGenericLegend("Control Plane CGroup CPU Rate", "percent",
+			dashboard.GridPos{X: 12, Y: 25, W: 12, H: 8},
+			promQuery(`sum by (id) (( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) * 100 * on (node) group_left kube_node_role{ role = "control-plane" } )`, "{{instance}}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("Workers CGroup Memory RSS", "bytes",
+			dashboard.GridPos{X: 0, Y: 33, W: 12, H: 8},
+			promQuery(`sum by (id) ( container_memory_rss{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"} * on (node) group_left kube_node_role{ role = "worker" } )`, "{{instance}}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("Control Plane CGroup Memory RSS", "bytes",
+			dashboard.GridPos{X: 12, Y: 33, W: 12, H: 8},
+			promQuery(`sum by (id) ( container_memory_rss{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"} * on (node) group_left kube_node_role{ role = "control-plane" } )`, "{{instance}}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("Workers Container Threads", "short",
+			dashboard.GridPos{X: 0, Y: 41, W: 12, H: 8},
+			promQuery(`sum by (node) (container_threads{ container!=""})  * on (node) group_left kube_node_role{ role = "worker" }`, "{{instance}}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("Control Plane Container Threads", "short",
+			dashboard.GridPos{X: 12, Y: 41, W: 12, H: 8},
+			promQuery(`sum by (node) (container_threads{ container!=""})  * on (node) group_left kube_node_role{ role = "control-plane" }`, "{{instance}}"),
+		)).
+		WithPanel(ocpGenericLegend("Workers Disk IOPS", "short",
+			dashboard.GridPos{X: 0, Y: 49, W: 12, H: 8},
+			promQuery(`rate( (  node_disk_reads_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "worker" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - read"),
+			promQuery(`rate( (  node_disk_writes_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "worker" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - write"),
+		)).
+		WithPanel(ocpGenericLegend("Control Plane Disk IOPS", "short",
+			dashboard.GridPos{X: 12, Y: 49, W: 12, H: 8},
+			promQuery(`rate( (  node_disk_reads_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "control-plane" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - read"),
+			promQuery(`rate( (  node_disk_writes_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "control-plane" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - write"),
+		))
+}
+
+// Row: OVN
+func ocpOVNRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("OVN").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(ocpGenericLegend("Top 10 ovnkube-controller CPU Usage", "percent",
+			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 8},
+			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovnkube-controller"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 ovnkube-controller Memory Usage", "bytes",
+			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 8},
+			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="ovnkube-controller"}) by (pod,node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 ovn-controller CPU Usage", "percent",
+			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 8},
+			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 ovn-controller Memory Usage", "bytes",
+			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 8},
+			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"}) by (pod,node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 nbdb CPU Usage", "percent",
+			dashboard.GridPos{X: 0, Y: 16, W: 12, H: 8},
+			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="nbdb"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 nbdb Memory Usage", "bytes",
+			dashboard.GridPos{X: 12, Y: 16, W: 12, H: 8},
+			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="nbdb"}) by (pod,node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 northd CPU Usage", "percent",
+			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
+			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="northd"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 northd Memory Usage", "bytes",
+			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
+			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="northd"}) by (pod,node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 sbdb CPU Usage", "percent",
+			dashboard.GridPos{X: 0, Y: 32, W: 12, H: 8},
+			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="sbdb"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 sbdb Memory Usage", "bytes",
+			dashboard.GridPos{X: 12, Y: 32, W: 12, H: 8},
+			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="sbdb"}) by (pod,node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("ovs-master CPU Usage", "percent",
+			dashboard.GridPos{X: 0, Y: 40, W: 12, H: 8},
+			promQuery(`irate(container_cpu_usage_seconds_total{id=~"/.*/ovs-vswitchd.service", node=~"$_master_node"}[$interval])*100`, "OVS CPU - {{ node }}"),
+			promQuery(`irate(container_cpu_usage_seconds_total{id=~"/.*/ovsdb-server.service", node=~"$_master_node"}[$interval])*100`, "OVS DB CPU - {{ node }}"),
+		)).
+		WithPanel(ocpGenericLegend("ovs-master Memory Usage", "bytes",
+			dashboard.GridPos{X: 12, Y: 40, W: 12, H: 8},
+			promQuery(`container_memory_rss{id=~"/.*/ovs-vswitchd.service", node=~"$_master_node"}`, "OVS Memory - {{ node }}"),
+			promQuery(`container_memory_rss{id=~"/.*/ovsdb-server.service", node=~"$_master_node"}`, "OVS DB Memory - {{ node }}"),
+		)).
+		WithPanel(ocpGenericLegend("ovs-worker CPU Usage", "percent",
+			dashboard.GridPos{X: 0, Y: 48, W: 12, H: 8},
+			promQuery(`irate(container_cpu_usage_seconds_total{id=~"/.*/ovs-vswitchd.service", node=~"$_worker_node"}[$interval])*100`, "OVS CPU - {{ node }}"),
+			promQuery(`irate(container_cpu_usage_seconds_total{id=~"/.*/ovsdb-server.service", node=~"$_worker_node"}[$interval])*100`, "OVS DB CPU - {{ node }}"),
+		)).
+		WithPanel(ocpGenericLegend("ovs-worker Memory Usage", "bytes",
+			dashboard.GridPos{X: 12, Y: 48, W: 12, H: 8},
+			promQuery(`container_memory_rss{id=~"/.*/ovs-vswitchd.service", node=~"$_worker_node"}`, "OVS Memory - {{ node }}"),
+			promQuery(`container_memory_rss{id=~"/.*/ovsdb-server.service", node=~"$_worker_node"}`, "OVS DB Memory - {{ node }}"),
+		)).
+		WithPanel(ocpGenericLegend("99% Pod Annotation Latency", "s",
+			dashboard.GridPos{X: 0, Y: 56, W: 8, H: 8},
+			promQuery(`histogram_quantile(0.99, sum by (instance, pod, le) (rate(ovnkube_controller_pod_creation_latency_seconds_bucket[$interval]))) > 0`, "{{ pod }} - {{ instance }}"),
+		)).
+		WithPanel(ocpGenericLegend("99% CNI Request ADD Latency", "s",
+			dashboard.GridPos{X: 8, Y: 56, W: 8, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(ovnkube_node_cni_request_duration_seconds_bucket{command="ADD"}[$interval])) by (instance,pod,le)) > 0`, "{{ pod }} - {{ instance }}"),
+		)).
+		WithPanel(ocpGenericLegend("99% CNI Request DEL Latency", "s",
+			dashboard.GridPos{X: 16, Y: 56, W: 8, H: 8},
+			promQuery(`histogram_quantile(0.99, sum(rate(ovnkube_node_cni_request_duration_seconds_bucket{command="DEL"}[$interval])) by (instance,pod,le)) > 0`, "{{ pod }} - {{ instance }}"),
+		)).
+		WithPanel(ocpGenericLegend("ovnkube-control-plane CPU Usage", "percent",
+			dashboard.GridPos{X: 0, Y: 64, W: 12, H: 8},
+			promQuery(`sum( irate(container_cpu_usage_seconds_total{pod=~"(ovnkube-master|ovnkube-control-plane).+",namespace="openshift-ovn-kubernetes",container!~"POD|"}[$interval])*100 ) by (pod, node)`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("ovnkube-control-plane Memory Usage", "bytes",
+			dashboard.GridPos{X: 12, Y: 64, W: 12, H: 8},
+			promQuery(`container_memory_rss{pod=~"(ovnkube-master|ovnkube-control-plane).+",namespace="openshift-ovn-kubernetes",container!~"POD|"}`, "{{pod}} - {{node}}"),
+		))
+}
+
+// Row: Monitoring stack
+func ocpMonitoringStackRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Monitoring stack").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(ocpGenericLegend("Prometheus Replica CPU", "percent",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`sum(irate(container_cpu_usage_seconds_total{pod=~"prometheus-k8s-0",namespace!="",name!="",container="prometheus"}[$interval])) by (pod,container,node) * 100`, "{{pod}} - {{node}}"),
+			promQuery(`sum(irate(container_cpu_usage_seconds_total{pod=~"prometheus-k8s-1",namespace!="",name!="",container="prometheus"}[$interval])) by (pod,container,node) * 100`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("Prometheus Replica RSS", "bytes",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`sum(container_memory_rss{pod="prometheus-k8s-1",namespace!="",name!="",container="prometheus"}) by (pod)`, "{{pod}}"),
+			promQuery(`sum(container_memory_rss{pod="prometheus-k8s-0",namespace!="",name!="",container="prometheus"}) by (pod)`, "{{pod}}"),
+		)).
+		WithPanel(ocpGenericLegend("metrics-server/prom-adapter CPU", "percent",
+			dashboard.GridPos{X: 0, Y: 10, W: 12, H: 8},
+			promQuery(`sum(irate(container_cpu_usage_seconds_total{pod=~"metrics-server-.*",namespace!="",name!=""}[$interval])) by (pod,container) * 100`, "{{pod}}"),
+			promQuery(`sum(irate(container_cpu_usage_seconds_total{pod=~"prometheus-adapter-.*",namespace="openshift-monitoring",name!=""}[$interval])) by (pod,container) * 100`, "{{pod}}"),
+		)).
+		WithPanel(ocpGenericLegend("metrics-server/prom-adapter RSS", "bytes",
+			dashboard.GridPos{X: 12, Y: 10, W: 12, H: 8},
+			promQuery(`sum(container_memory_rss{pod=~"metrics-server-.*",namespace!="",name!=""}) by (pod)`, "{{pod}}"),
+			promQuery(`sum(container_memory_rss{pod=~"prometheus-adapter-.*",namespace="openshift-monitoring",name!=""}) by (pod)`, "{{pod}}"),
+		))
+}
+
+// Row: Stackrox
+func ocpStackroxRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Stackrox").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(ocpGenericLegend("Top 25 stackrox container RSS bytes", "bytes",
+			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
+			promQuery(`topk(25, container_memory_rss{container!="POD",name!="",namespace!="",namespace=~"stackrox"})`, "{{ pod }}: {{ container }}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 25 stackrox container CPU percent", "percent",
+			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
+			promQuery(`topk(25, sum(irate(container_cpu_usage_seconds_total{container!="POD",name!="",namespace!="",namespace=~"stackrox"}[$interval])) by (pod,container,namespace,name,service) * 100)`, "{{ pod }}: {{ container }}"),
+		))
+}
+
+// Row: Cluster Kubelet
+func ocpClusterKubeletRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Cluster Kubelet").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(ocpGenericLegend("Top 10 Kubelet CPU usage", "percent",
+			dashboard.GridPos{X: 0, Y: 3, W: 12, H: 8},
+			promQuery(`topk(10,irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[$interval])*100 *  on (node) group_left kube_node_role{ role = "worker" })`, "kubelet - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 crio CPU usage", "percent",
+			dashboard.GridPos{X: 12, Y: 3, W: 12, H: 8},
+			promQuery(`topk(10,irate(process_cpu_seconds_total{service="kubelet",job="crio"}[$interval])*100 *  on (node) group_left kube_node_role{ role = "worker" })`, "crio - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("Top 10 Kubelet memory usage", "bytes",
+			dashboard.GridPos{X: 0, Y: 11, W: 12, H: 8},
+			promQuery(`topk(10,process_resident_memory_bytes{service="kubelet",job="kubelet"} *  on (node) group_left kube_node_role{ role = "worker" })`, "kubelet - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("Top 10 crio memory usage", "bytes",
+			dashboard.GridPos{X: 12, Y: 11, W: 12, H: 8},
+			promQuery(`topk(10,process_resident_memory_bytes{service="kubelet",job="crio"} *  on (node) group_left kube_node_role{ role = "worker" })`, "crio - {{node}}"),
+		)).
+		WithPanel(ocpGenericLegend("inodes usage in /run", "percent",
+			dashboard.GridPos{X: 0, Y: 19, W: 12, H: 8},
+			promQuery(`(1 - node_filesystem_files_free{fstype!="",mountpoint="/run"} / node_filesystem_files{fstype!="",mountpoint="/run"}) * 100`, "{{instance}}"),
+		)).
+		WithPanel(ocpGenericLegendCounterSumRightHand("inodes count in /run", "none",
+			dashboard.GridPos{X: 12, Y: 19, W: 12, H: 8},
+			promQuery(`node_filesystem_files{fstype!="",mountpoint="/run"} - node_filesystem_files_free{fstype!="",mountpoint="/run"}`, "{{instance}}"),
+			promQuery(`sum(node_filesystem_files{fstype!="",mountpoint="/run"} - node_filesystem_files_free{fstype!="",mountpoint="/run"})`, "sum"),
+		))
+}
+
+// Row: Cluster Details
+func ocpClusterDetailsRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Cluster Details").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(ocpStat("Current Node Count",
+			dashboard.GridPos{X: 0, Y: 4, W: 8, H: 3},
+			promQuery(`sum(kube_node_info{})`, "Number of nodes"),
+			promQuery(`sum(kube_node_status_condition{status="true"}) by (condition) > 0`, "Node: {{ condition }}"),
+		)).
+		WithPanel(ocpStat("Current Namespace Count",
+			dashboard.GridPos{X: 8, Y: 4, W: 8, H: 3},
+			promQuery(`sum(kube_namespace_status_phase) by (phase)`, "{{ phase }}"),
+		)).
+		WithPanel(ocpStat("Current Pod Count",
+			dashboard.GridPos{X: 16, Y: 4, W: 8, H: 3},
+			promQuery(`sum(kube_pod_status_phase{}) by (phase) > 0`, "{{ phase}} Pods"),
+		)).
+		WithPanel(ocpGeneric("Number of nodes", "none",
+			dashboard.GridPos{X: 0, Y: 12, W: 8, H: 8},
+			promQuery(`sum(kube_node_info{})`, "Number of nodes"),
+			promQuery(`sum(kube_node_status_condition{status="true"}) by (condition) > 0`, "Node: {{ condition }}"),
+		)).
+		WithPanel(ocpGeneric("Namespace count", "none",
+			dashboard.GridPos{X: 8, Y: 12, W: 8, H: 8},
+			promQuery(`sum(kube_namespace_status_phase) by (phase) > 0`, "{{ phase }} namespaces"),
+		)).
+		WithPanel(ocpGeneric("Pod count", "none",
+			dashboard.GridPos{X: 16, Y: 12, W: 8, H: 8},
+			promQuery(`sum(kube_pod_status_phase{}) by (phase)`, "{{phase}} pods"),
+		)).
+		WithPanel(ocpGeneric("Secret & configmap count", "none",
+			dashboard.GridPos{X: 0, Y: 20, W: 8, H: 8},
+			promQuery(`count(kube_secret_info{})`, "secrets"),
+			promQuery(`count(kube_configmap_info{})`, "Configmaps"),
+		)).
+		WithPanel(ocpGeneric("Deployment count", "none",
+			dashboard.GridPos{X: 8, Y: 20, W: 8, H: 8},
+			promQuery(`count(kube_deployment_labels{})`, "Deployments"),
+		)).
+		WithPanel(ocpGeneric("Services count", "none",
+			dashboard.GridPos{X: 16, Y: 20, W: 8, H: 8},
+			promQuery(`count(kube_service_info{})`, "Services"),
+		)).
+		WithPanel(ocpGeneric("Routes count", "none",
+			dashboard.GridPos{X: 0, Y: 20, W: 8, H: 8},
+			promQuery(`count(openshift_route_info{})`, "Routes"),
+		)).
+		WithPanel(ocpGeneric("Alerts", "none",
+			dashboard.GridPos{X: 8, Y: 20, W: 8, H: 8},
+			promQuery(`topk(10,sum(ALERTS{severity!="none"}) by (alertname, severity))`, "{{severity}}: {{alertname}}"),
+		)).
+		WithPanel(ocpGenericLegend("Pod Distribution", "none",
+			dashboard.GridPos{X: 16, Y: 20, W: 8, H: 8},
+			promQuery(`count(kube_pod_info{}) by (node)`, "{{ node }}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 container CPU", "percent",
+			dashboard.GridPos{X: 0, Y: 28, W: 12, H: 8},
+			promQuery(`topk(10,irate(container_cpu_usage_seconds_total{namespace!="",container!="POD",name!=""}[$interval])*100)`, "{{ namespace }} - {{ name }} - {{ node }}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 container RSS", "bytes",
+			dashboard.GridPos{X: 12, Y: 28, W: 12, H: 8},
+			promQuery(`topk(10, container_memory_rss{namespace!="",container!="POD",name!=""})`, "{{ namespace }} - {{ name }} - {{ node }}"),
+		)).
+		WithPanel(ocpGenericLegend("container RSS system.slice", "bytes",
+			dashboard.GridPos{X: 12, Y: 36, W: 12, H: 8},
+			promQuery(`sum by (node)(container_memory_rss{id="/system.slice"})`, "system.slice - {{ node }}"),
+		)).
+		WithPanel(ocpGeneric("Goroutines count", "none",
+			dashboard.GridPos{X: 0, Y: 36, W: 12, H: 8},
+			promQuery(`topk(10, sum(go_goroutines{}) by (job,instance))`, "{{ job }} - {{ instance }}"),
+		))
+}
+
+// Row: Cluster Operators Details
+func ocpClusterOperatorsDetailsRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Cluster Operators Details").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(ocpStat("Cluster operators overview",
+			dashboard.GridPos{X: 0, Y: 4, W: 24, H: 3},
+			promQuery(`sum by (condition)(cluster_operator_conditions{condition!=""})`, "{{ condition }}"),
+		)).
+		WithPanel(ocpGenericLegend("Cluster operators information", "none",
+			dashboard.GridPos{X: 0, Y: 4, W: 8, H: 8},
+			promQuery(`cluster_operator_conditions{name!="",reason!=""}`, "{{name}} - {{reason}}"),
+		)).
+		WithPanel(ocpGenericLegend("Cluster operators degraded", "none",
+			dashboard.GridPos{X: 8, Y: 4, W: 8, H: 8},
+			promQuery(`cluster_operator_conditions{condition="Degraded",name!="",reason!=""}`, "{{name}} - {{reason}}"),
+		))
+}
+
+// Row: Master (repeats on _master_node)
+func ocpMasterRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Master: $_master_node").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 8}).
+		Repeat("_master_node").
+		WithPanel(ocpGenericLegend("CPU Basic: $_master_node", "percent",
+			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 8},
+			promQuery(`sum by (instance, mode)(irate(node_cpu_seconds_total{instance=~"$_master_node",job=~".*"}[$interval])) * 100`, "Busy {{mode}}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("System Memory: $_master_node", "bytes",
+			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 8},
+			promQuery(`node_memory_Active_bytes{instance=~"$_master_node"}`, "Active"),
+			promQuery(`node_memory_MemTotal_bytes{instance=~"$_master_node"}`, "Total"),
+			promQuery(`node_memory_Cached_bytes{instance=~"$_master_node"} + node_memory_Buffers_bytes{instance=~"$_master_node"}`, "Cached + Buffers"),
+			promQuery(`node_memory_MemAvailable_bytes{instance=~"$_master_node"}`, "Available"),
+			promQuery(`(node_memory_MemTotal_bytes{instance=~"$_master_node"} - (node_memory_MemFree_bytes{instance=~"$_master_node"} + node_memory_Buffers_bytes{instance=~"$_master_node"} +  node_memory_Cached_bytes{instance=~"$_master_node"}))`, "Used"),
+		)).
+		WithPanel(ocpGenericLegend("Disk throughput: $_master_node", "Bps",
+			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 8},
+			promQuery(`rate(node_disk_read_bytes_total{device=~"$block_device",instance=~"$_master_node"}[$interval])`, "{{ device }} - read"),
+			promQuery(`rate(node_disk_written_bytes_total{device=~"$block_device",instance=~"$_master_node"}[$interval])`, "{{ device }} - write"),
+		)).
+		WithPanel(ocpGenericLegend("Disk IOPS: $_master_node", "iops",
+			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 8},
+			promQuery(`rate(node_disk_reads_completed_total{device=~"$block_device",instance=~"$_master_node"}[$interval])`, "{{ device }} - read"),
+			promQuery(`rate(node_disk_writes_completed_total{device=~"$block_device",instance=~"$_master_node"}[$interval])`, "{{ device }} - write"),
+		)).
+		WithPanel(ocpGenericLegend("Network Utilization: $_master_node", "bps",
+			dashboard.GridPos{X: 0, Y: 16, W: 12, H: 8},
+			promQuery(`rate(node_network_receive_bytes_total{instance=~"$_master_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - RX"),
+			promQuery(`rate(node_network_transmit_bytes_total{instance=~"$_master_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - TX"),
+		)).
+		WithPanel(ocpGenericLegend("Network Packets: $_master_node", "pps",
+			dashboard.GridPos{X: 12, Y: 16, W: 12, H: 8},
+			promQuery(`rate(node_network_receive_packets_total{instance=~"$_master_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - RX"),
+			promQuery(`rate(node_network_transmit_packets_total{instance=~"$_master_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - TX"),
+		)).
+		WithPanel(ocpGenericLegend("Network packets drop: $_master_node", "pps",
+			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
+			promQuery(`topk(10, rate(node_network_receive_drop_total{instance=~"$_master_node"}[$interval]))`, "rx-drop-{{ device }}"),
+			promQuery(`topk(10,rate(node_network_transmit_drop_total{instance=~"$_master_node"}[$interval]))`, "tx-drop-{{ device }}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("Conntrack stats: $_master_node", "",
+			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
+			promQuery(`node_nf_conntrack_entries{instance=~"$_master_node"}`, "conntrack_entries"),
+			promQuery(`node_nf_conntrack_entries_limit{instance=~"$_master_node"}`, "conntrack_limit"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 container CPU: $_master_node", "percent",
+			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
+			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container!="POD",name!="",node=~"$_master_node",namespace!="",namespace=~"$namespace"}[$interval])) by (pod,container,namespace,name,service) * 100)`, "{{ pod }}: {{ container }}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("Top 10 container RSS: $_master_node", "bytes",
+			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
+			promQuery(`topk(10, container_memory_rss{container!="POD",name!="",node=~"$_master_node",namespace!="",namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
+		)).
+		WithPanel(ocpGenericLegend("cgroup CPU: $_master_node", "percent",
+			dashboard.GridPos{X: 0, Y: 32, W: 12, H: 8},
+			promQuery(`sum by (id) ( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice", node=~"$_master_node"}[$interval])) * 100`, "{{ id }}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("cgroup RSS: $_master_node", "bytes",
+			dashboard.GridPos{X: 12, Y: 32, W: 12, H: 8},
+			promQuery(`sum by (id) ( container_memory_rss{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/system.slice/.*.service|/system.slice/systemd-udevd.service|/kubepods.slice", node=~"$_master_node"})`, "{{ id }}"),
+		)).
+		WithPanel(ocpGenericLegend("Pod fs rw rate: $_master_node", "Bps",
+			dashboard.GridPos{X: 0, Y: 32, W: 12, H: 8},
+			promQuery(`sum(rate(container_fs_writes_bytes_total{device!~".+dm.+", node=~"$_master_node", pod!=""}[$interval])) by (device, pod)`, "{{ pod }}: {{ device }} - write"),
+			promQuery(`sum(rate(container_fs_reads_bytes_total{device!~".+dm.+", node=~"$_master_node", pod!=""}[$interval])) by (device, pod)`, "{{ pod }}: {{ device }} - read"),
+		)).
+		WithPanel(ocpGenericLegend("cgroup fs rw rate: $_master_node", "Bps",
+			dashboard.GridPos{X: 12, Y: 32, W: 12, H: 8},
+			promQuery(`sum(rate(container_fs_writes_bytes_total{device!~".+dm.+", node=~"$_master_node", id =~"/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) by (device, id)`, "{{ id }}: {{ device }} - write"),
+			promQuery(`sum(rate(container_fs_reads_bytes_total{device!~".+dm.+", node=~"$_master_node", id =~"/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) by (device, id)`, "{{ id }}: {{ device }} - read"),
+		))
+}
+
+// Row: Worker (repeats on _worker_node)
+func ocpWorkerRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Worker: $_worker_node").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 8}).
+		Repeat("_worker_node").
+		WithPanel(ocpGenericLegend("CPU Basic: $_worker_node", "percent",
+			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 8},
+			promQuery(`sum by (instance, mode)(irate(node_cpu_seconds_total{instance=~"$_worker_node",job=~".*"}[$interval])) * 100`, "Busy {{mode}}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("System Memory: $_worker_node", "bytes",
+			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 8},
+			promQuery(`node_memory_Active_bytes{instance=~"$_worker_node"}`, "Active"),
+			promQuery(`node_memory_MemTotal_bytes{instance=~"$_worker_node"}`, "Total"),
+			promQuery(`node_memory_Cached_bytes{instance=~"$_worker_node"} + node_memory_Buffers_bytes{instance=~"$_worker_node"}`, "Cached + Buffers"),
+			promQuery(`node_memory_MemAvailable_bytes{instance=~"$_worker_node"}`, "Available"),
+			promQuery(`(node_memory_MemTotal_bytes{instance=~"$_worker_node"} - (node_memory_MemFree_bytes{instance=~"$_worker_node"} + node_memory_Buffers_bytes{instance=~"$_worker_node"} +  node_memory_Cached_bytes{instance=~"$_worker_node"}))`, "Used"),
+		)).
+		WithPanel(ocpGenericLegend("Disk throughput: $_worker_node", "Bps",
+			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 8},
+			promQuery(`rate(node_disk_read_bytes_total{device=~"$block_device",instance=~"$_worker_node"}[$interval])`, "{{ device }} - read"),
+			promQuery(`rate(node_disk_written_bytes_total{device=~"$block_device",instance=~"$_worker_node"}[$interval])`, "{{ device }} - write"),
+		)).
+		WithPanel(ocpGenericLegend("Disk IOPS: $_worker_node", "iops",
+			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 8},
+			promQuery(`rate(node_disk_reads_completed_total{device=~"$block_device",instance=~"$_worker_node"}[$interval])`, "{{ device }} - read"),
+			promQuery(`rate(node_disk_writes_completed_total{device=~"$block_device",instance=~"$_worker_node"}[$interval])`, "{{ device }} - write"),
+		)).
+		WithPanel(ocpGenericLegend("Network Utilization: $_worker_node", "bps",
+			dashboard.GridPos{X: 0, Y: 16, W: 12, H: 8},
+			promQuery(`rate(node_network_receive_bytes_total{instance=~"$_worker_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - RX"),
+			promQuery(`rate(node_network_transmit_bytes_total{instance=~"$_worker_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - TX"),
+		)).
+		WithPanel(ocpGenericLegend("Network Packets: $_worker_node", "pps",
+			dashboard.GridPos{X: 12, Y: 16, W: 12, H: 8},
+			promQuery(`rate(node_network_receive_packets_total{instance=~"$_worker_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - RX"),
+			promQuery(`rate(node_network_transmit_packets_total{instance=~"$_worker_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - TX"),
+		)).
+		WithPanel(ocpGenericLegend("Network packets drop: $_worker_node", "pps",
+			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
+			promQuery(`topk(10, rate(node_network_receive_drop_total{instance=~"$_worker_node"}[$interval]))`, "rx-drop-{{ device }}"),
+			promQuery(`topk(10,rate(node_network_transmit_drop_total{instance=~"$_worker_node"}[$interval]))`, "tx-drop-{{ device }}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("Conntrack stats: $_worker_node", "",
+			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
+			promQuery(`node_nf_conntrack_entries{instance=~"$_worker_node"}`, "conntrack_entries"),
+			promQuery(`node_nf_conntrack_entries_limit{instance=~"$_worker_node"}`, "conntrack_limit"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 container CPU: $_worker_node", "percent",
+			dashboard.GridPos{X: 0, Y: 32, W: 12, H: 8},
+			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container!="POD",name!="",node=~"$_worker_node",namespace!="",namespace=~"$namespace"}[$interval])) by (pod,container,namespace,name,service) * 100)`, "{{ pod }}: {{ container }}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("Top 10 container RSS: $_worker_node", "bytes",
+			dashboard.GridPos{X: 12, Y: 32, W: 12, H: 8},
+			promQuery(`topk(10, container_memory_rss{container!="POD",name!="",node=~"$_worker_node",namespace!="",namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
+		)).
+		WithPanel(ocpGenericLegend("cgroup CPU: $_worker_node", "percent",
+			dashboard.GridPos{X: 0, Y: 40, W: 12, H: 8},
+			promQuery(`sum by (id) ( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice", node=~"$_worker_node"}[$interval])) * 100`, "{{ id }}"),
+		)).
+		WithPanel(ocpGenericLegendCounter("cgroup RSS: $_worker_node", "bytes",
+			dashboard.GridPos{X: 12, Y: 40, W: 12, H: 8},
+			promQuery(`sum by (id) ( container_memory_rss{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/system.slice/.*.service|/system.slice/systemd-udevd.service|/kubepods.slice", node=~"$_worker_node"})`, "{{ id }}"),
+		))
+}
+
+// Row: Infra (repeats on _infra_node)
+func ocpInfraRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Infra: $_infra_node").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 8}).
+		Repeat("_infra_node").
+		WithPanel(ocpGenericLegend("CPU Basic: $_infra_node", "percent",
+			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 8},
+			promQuery(`sum by (instance, mode)(irate(node_cpu_seconds_total{instance=~"$_infra_node",job=~".*"}[$interval])) * 100`, "Busy {{mode}}"),
+		)).
+		WithPanel(ocpGenericLegend("System Memory: $_infra_node", "bytes",
+			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 8},
+			promQuery(`node_memory_Active_bytes{instance=~"$_infra_node"}`, "Active"),
+			promQuery(`node_memory_MemTotal_bytes{instance=~"$_infra_node"}`, "Total"),
+			promQuery(`node_memory_Cached_bytes{instance=~"$_infra_node"} + node_memory_Buffers_bytes{instance=~"$_infra_node"}`, "Cached + Buffers"),
+			promQuery(`node_memory_MemAvailable_bytes{instance=~"$_infra_node"}`, "Available"),
+			promQuery(`(node_memory_MemTotal_bytes{instance=~"$_infra_node"} - (node_memory_MemFree_bytes{instance=~"$_infra_node"} + node_memory_Buffers_bytes{instance=~"$_infra_node"} +  node_memory_Cached_bytes{instance=~"$_infra_node"}))`, "Used"),
+		)).
+		WithPanel(ocpGenericLegend("Disk throughput: $_infra_node", "Bps",
+			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 8},
+			promQuery(`rate(node_disk_read_bytes_total{device=~"$block_device",instance=~"$_infra_node"}[$interval])`, "{{ device }} - read"),
+			promQuery(`rate(node_disk_written_bytes_total{device=~"$block_device",instance=~"$_infra_node"}[$interval])`, "{{ device }} - write"),
+		)).
+		WithPanel(ocpGenericLegend("Disk IOPS: $_infra_node", "iops",
+			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 8},
+			promQuery(`rate(node_disk_reads_completed_total{device=~"$block_device",instance=~"$_infra_node"}[$interval])`, "{{ device }} - read"),
+			promQuery(`rate(node_disk_writes_completed_total{device=~"$block_device",instance=~"$_infra_node"}[$interval])`, "{{ device }} - write"),
+		)).
+		WithPanel(ocpGenericLegend("Network Utilization: $_infra_node", "bps",
+			dashboard.GridPos{X: 0, Y: 16, W: 12, H: 8},
+			promQuery(`rate(node_network_receive_bytes_total{instance=~"$_infra_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - RX"),
+			promQuery(`rate(node_network_transmit_bytes_total{instance=~"$_infra_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - TX"),
+		)).
+		WithPanel(ocpGenericLegend("Network Packets: $_infra_node", "pps",
+			dashboard.GridPos{X: 12, Y: 16, W: 12, H: 8},
+			promQuery(`rate(node_network_receive_packets_total{instance=~"$_infra_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - RX"),
+			promQuery(`rate(node_network_transmit_packets_total{instance=~"$_infra_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - TX"),
+		)).
+		WithPanel(ocpGenericLegend("Network packets drop: $_infra_node", "pps",
+			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
+			promQuery(`topk(10, rate(node_network_receive_drop_total{instance=~"$_infra_node"}[$interval]))`, "rx-drop-{{ device }}"),
+			promQuery(`topk(10,rate(node_network_transmit_drop_total{instance=~"$_infra_node"}[$interval]))`, "tx-drop-{{ device }}"),
+		)).
+		WithPanel(ocpGenericLegend("Conntrack stats: $_infra_node", "",
+			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
+			promQuery(`node_nf_conntrack_entries{instance=~"$_infra_node"}`, "conntrack_entries"),
+			promQuery(`node_nf_conntrack_entries_limit{instance=~"$_infra_node"}`, "conntrack_limit"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 container CPU: $_infra_node", "percent",
+			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
+			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container!="POD",name!="",node=~"$_infra_node",namespace!="",namespace=~"$namespace"}[$interval])) by (pod,container,namespace,name,service) * 100)`, "{{ pod }}: {{ container }}"),
+		)).
+		WithPanel(ocpGenericLegend("Top 10 container RSS: $_infra_node", "bytes",
+			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
+			promQuery(`topk(10, container_memory_rss{container!="POD",name!="",node=~"$_infra_node",namespace!="",namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
+		))
+}

--- a/go/ocp_performance.go
+++ b/go/ocp_performance.go
@@ -371,7 +371,7 @@ func ocpClusterDetailsRow() *dashboard.RowBuilder {
 		)).
 		WithPanel(genericTimeSeries("Deployment count", "none",
 			dashboard.GridPos{X: 8, Y: 20, W: 8, H: 8},
-			promQuery(`count(kube_deployment_labels{})`, "Deployments"),
+			promQuery(`count(kube_deployment_spec_replicas{})`, "Deployments"),
 		)).
 		WithPanel(genericTimeSeries("Services count", "none",
 			dashboard.GridPos{X: 16, Y: 20, W: 8, H: 8},

--- a/go/ocp_performance.go
+++ b/go/ocp_performance.go
@@ -2,11 +2,7 @@ package main
 
 import (
 	"github.com/grafana/grafana-foundation-sdk/go/cog"
-	"github.com/grafana/grafana-foundation-sdk/go/common"
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
-	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
-	"github.com/grafana/grafana-foundation-sdk/go/stat"
-	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
 )
 
 func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
@@ -108,187 +104,68 @@ func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
 		WithRow(ocpStackroxRow())
 }
 
-func intervalOption(val string) dashboard.VariableOption {
-	return dashboard.VariableOption{
-		Text:  dashboard.StringOrArrayOfString{String: &val},
-		Value: dashboard.StringOrArrayOfString{String: &val},
-	}
-}
-
-func promDatasourceRef() common.DataSourceRef {
-	return common.DataSourceRef{
-		Type: cog.ToPtr("prometheus"),
-		Uid:  cog.ToPtr("${Datasource}"),
-	}
-}
-
-func promQuery(expr, legend string) *prometheus.DataqueryBuilder {
-	return prometheus.NewDataqueryBuilder().
-		Expr(expr).
-		LegendFormat(legend).
-		Format(prometheus.PromQueryFormatTimeSeries).
-		IntervalFactor(2)
-}
-
-// Panel type: generic - base timeseries with tooltip multi/desc, legend table mode
-func ocpGeneric(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
-	p := timeseries.NewPanelBuilder().
-		Title(title).
-		Datasource(promDatasourceRef()).
-		Unit(unit).
-		GridPos(gridPos).
-		SpanNulls(boolPtr(false)).
-		Tooltip(common.NewVizTooltipOptionsBuilder().
-			Mode(common.TooltipDisplayModeMulti).
-			Sort(common.SortOrderDescending),
-		).
-		Legend(common.NewVizLegendOptionsBuilder().
-			ShowLegend(true).
-			DisplayMode(common.LegendDisplayModeTable),
-		)
-	for _, t := range targets {
-		p = p.WithTarget(t)
-	}
-	return p
-}
-
-// Panel type: genericLegend - extends generic with calcs [mean, min, max], sortBy Max desc, placement bottom
-func ocpGenericLegend(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
-	p := timeseries.NewPanelBuilder().
-		Title(title).
-		Datasource(promDatasourceRef()).
-		Unit(unit).
-		GridPos(gridPos).
-		SpanNulls(boolPtr(false)).
-		Tooltip(common.NewVizTooltipOptionsBuilder().
-			Mode(common.TooltipDisplayModeMulti).
-			Sort(common.SortOrderDescending),
-		).
-		Legend(common.NewVizLegendOptionsBuilder().
-			ShowLegend(true).
-			DisplayMode(common.LegendDisplayModeTable).
-			Calcs([]string{"mean", "min", "max"}).
-			SortBy("Max").
-			SortDesc(true).
-			Placement(common.LegendPlacementBottom),
-		)
-	for _, t := range targets {
-		p = p.WithTarget(t)
-	}
-	return p
-}
-
-// Panel type: genericLegendCounter - extends generic with calcs [first, min, max, last], sortBy Max desc, placement bottom
-func ocpGenericLegendCounter(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
-	p := timeseries.NewPanelBuilder().
-		Title(title).
-		Datasource(promDatasourceRef()).
-		Unit(unit).
-		GridPos(gridPos).
-		SpanNulls(boolPtr(false)).
-		Tooltip(common.NewVizTooltipOptionsBuilder().
-			Mode(common.TooltipDisplayModeMulti).
-			Sort(common.SortOrderDescending),
-		).
-		Legend(common.NewVizLegendOptionsBuilder().
-			ShowLegend(true).
-			DisplayMode(common.LegendDisplayModeTable).
-			Calcs([]string{"first", "min", "max", "last"}).
-			SortBy("Max").
-			SortDesc(true).
-			Placement(common.LegendPlacementBottom),
-		)
-	for _, t := range targets {
-		p = p.WithTarget(t)
-	}
-	return p
-}
-
-// Panel type: genericLegendCounterSumRightHand - extends genericLegendCounter with override for 'sum' series on right axis
-func ocpGenericLegendCounterSumRightHand(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
-	p := ocpGenericLegendCounter(title, unit, gridPos, targets...)
-	return p.OverrideByRegexp("sum", []dashboard.DynamicConfigValue{
-		{Id: "custom.axisPlacement", Value: "right"},
-		{Id: "custom.axisLabel", Value: "sum"},
-	})
-}
-
-// Stat panel
-func ocpStat(title string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *stat.PanelBuilder {
-	p := stat.NewPanelBuilder().
-		Title(title).
-		Datasource(promDatasourceRef()).
-		GridPos(gridPos).
-		ReduceOptions(common.NewReduceDataOptionsBuilder().
-			Calcs([]string{"last"}),
-		)
-	for _, t := range targets {
-		p = p.WithTarget(t)
-	}
-	return p
-}
 
 // Row: Cluster-at-a-Glance
 func ocpClusterAtAGlanceRow() *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Cluster-at-a-Glance").
 		Collapsed(true).
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
-		WithPanel(ocpGenericLegend("Workers CPU Usage", "percent",
+		WithPanel(genericLegendTimeSeries("Workers CPU Usage", "percent",
 			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
 			promQuery(`sum( rate( (node_cpu_seconds_total{ mode != "idle" } * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)") )[$interval:] ) ) by (instance) * 100`, "{{instance}}"),
 		)).
-		WithPanel(ocpGenericLegend("Control Plane CPU Usage", "percent",
+		WithPanel(genericLegendTimeSeries("Control Plane CPU Usage", "percent",
 			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
 			promQuery(`sum( rate( (node_cpu_seconds_total{ mode != "idle" } * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)") )[$interval:] ) ) by (instance) * 100`, "{{instance}}"),
 		)).
-		WithPanel(ocpGenericLegend("Workers Load1", "short",
+		WithPanel(genericLegendTimeSeries("Workers Load1", "short",
 			dashboard.GridPos{X: 0, Y: 9, W: 12, H: 8},
 			promQuery(`node_load1 * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)") `, "{{instance}}"),
 		)).
-		WithPanel(ocpGenericLegend("Control Plane Load1", "short",
+		WithPanel(genericLegendTimeSeries("Control Plane Load1", "short",
 			dashboard.GridPos{X: 12, Y: 9, W: 12, H: 8},
 			promQuery(`node_load1 * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)") `, "{{instance}}"),
 		)).
-		WithPanel(ocpGenericLegendCounterSumRightHand("Workers Memory Available", "bytes",
+		WithPanel(genericLegendCounterSumRightHandTimeSeries("Workers Memory Available", "bytes",
 			dashboard.GridPos{X: 0, Y: 17, W: 12, H: 8},
 			promQuery(`node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)")`, "{{instance}}"),
 			promQuery(`sum( node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)") )`, "sum"),
 		)).
-		WithPanel(ocpGenericLegendCounterSumRightHand("Control Plane Memory Available", "bytes",
+		WithPanel(genericLegendCounterSumRightHandTimeSeries("Control Plane Memory Available", "bytes",
 			dashboard.GridPos{X: 12, Y: 17, W: 12, H: 8},
 			promQuery(`node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)")`, "{{instance}}"),
 			promQuery(`sum( node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)") )`, "sum"),
 		)).
-		WithPanel(ocpGenericLegend("Workers CGroup CPU Rate", "percent",
+		WithPanel(genericLegendTimeSeries("Workers CGroup CPU Rate", "percent",
 			dashboard.GridPos{X: 0, Y: 25, W: 12, H: 8},
 			promQuery(`sum by (id) (( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) * 100 * on (node) group_left kube_node_role{ role = "worker" } )`, "{{instance}}"),
 		)).
-		WithPanel(ocpGenericLegend("Control Plane CGroup CPU Rate", "percent",
+		WithPanel(genericLegendTimeSeries("Control Plane CGroup CPU Rate", "percent",
 			dashboard.GridPos{X: 12, Y: 25, W: 12, H: 8},
 			promQuery(`sum by (id) (( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) * 100 * on (node) group_left kube_node_role{ role = "control-plane" } )`, "{{instance}}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("Workers CGroup Memory RSS", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("Workers CGroup Memory RSS", "bytes",
 			dashboard.GridPos{X: 0, Y: 33, W: 12, H: 8},
 			promQuery(`sum by (id) ( container_memory_rss{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"} * on (node) group_left kube_node_role{ role = "worker" } )`, "{{instance}}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("Control Plane CGroup Memory RSS", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("Control Plane CGroup Memory RSS", "bytes",
 			dashboard.GridPos{X: 12, Y: 33, W: 12, H: 8},
 			promQuery(`sum by (id) ( container_memory_rss{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"} * on (node) group_left kube_node_role{ role = "control-plane" } )`, "{{instance}}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("Workers Container Threads", "short",
+		WithPanel(genericLegendCounterTimeSeries("Workers Container Threads", "short",
 			dashboard.GridPos{X: 0, Y: 41, W: 12, H: 8},
 			promQuery(`sum by (node) (container_threads{ container!=""})  * on (node) group_left kube_node_role{ role = "worker" }`, "{{instance}}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("Control Plane Container Threads", "short",
+		WithPanel(genericLegendCounterTimeSeries("Control Plane Container Threads", "short",
 			dashboard.GridPos{X: 12, Y: 41, W: 12, H: 8},
 			promQuery(`sum by (node) (container_threads{ container!=""})  * on (node) group_left kube_node_role{ role = "control-plane" }`, "{{instance}}"),
 		)).
-		WithPanel(ocpGenericLegend("Workers Disk IOPS", "short",
+		WithPanel(genericLegendTimeSeries("Workers Disk IOPS", "short",
 			dashboard.GridPos{X: 0, Y: 49, W: 12, H: 8},
 			promQuery(`rate( (  node_disk_reads_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "worker" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - read"),
 			promQuery(`rate( (  node_disk_writes_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "worker" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - write"),
 		)).
-		WithPanel(ocpGenericLegend("Control Plane Disk IOPS", "short",
+		WithPanel(genericLegendTimeSeries("Control Plane Disk IOPS", "short",
 			dashboard.GridPos{X: 12, Y: 49, W: 12, H: 8},
 			promQuery(`rate( (  node_disk_reads_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "control-plane" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - read"),
 			promQuery(`rate( (  node_disk_writes_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "control-plane" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - write"),
@@ -300,83 +177,83 @@ func ocpOVNRow() *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("OVN").
 		Collapsed(true).
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
-		WithPanel(ocpGenericLegend("Top 10 ovnkube-controller CPU Usage", "percent",
+		WithPanel(genericLegendTimeSeries("Top 10 ovnkube-controller CPU Usage", "percent",
 			dashboard.GridPos{X: 0, Y: 1, W: 12, H: 8},
 			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovnkube-controller"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 ovnkube-controller Memory Usage", "bytes",
+		WithPanel(genericLegendTimeSeries("Top 10 ovnkube-controller Memory Usage", "bytes",
 			dashboard.GridPos{X: 12, Y: 1, W: 12, H: 8},
 			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="ovnkube-controller"}) by (pod,node))`, "{{pod}} - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 ovn-controller CPU Usage", "percent",
+		WithPanel(genericLegendTimeSeries("Top 10 ovn-controller CPU Usage", "percent",
 			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 8},
 			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 ovn-controller Memory Usage", "bytes",
+		WithPanel(genericLegendTimeSeries("Top 10 ovn-controller Memory Usage", "bytes",
 			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 8},
 			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"}) by (pod,node))`, "{{pod}} - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 nbdb CPU Usage", "percent",
+		WithPanel(genericLegendTimeSeries("Top 10 nbdb CPU Usage", "percent",
 			dashboard.GridPos{X: 0, Y: 16, W: 12, H: 8},
 			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="nbdb"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 nbdb Memory Usage", "bytes",
+		WithPanel(genericLegendTimeSeries("Top 10 nbdb Memory Usage", "bytes",
 			dashboard.GridPos{X: 12, Y: 16, W: 12, H: 8},
 			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="nbdb"}) by (pod,node))`, "{{pod}} - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 northd CPU Usage", "percent",
+		WithPanel(genericLegendTimeSeries("Top 10 northd CPU Usage", "percent",
 			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
 			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="northd"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 northd Memory Usage", "bytes",
+		WithPanel(genericLegendTimeSeries("Top 10 northd Memory Usage", "bytes",
 			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
 			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="northd"}) by (pod,node))`, "{{pod}} - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 sbdb CPU Usage", "percent",
+		WithPanel(genericLegendTimeSeries("Top 10 sbdb CPU Usage", "percent",
 			dashboard.GridPos{X: 0, Y: 32, W: 12, H: 8},
 			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="sbdb"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 sbdb Memory Usage", "bytes",
+		WithPanel(genericLegendTimeSeries("Top 10 sbdb Memory Usage", "bytes",
 			dashboard.GridPos{X: 12, Y: 32, W: 12, H: 8},
 			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="sbdb"}) by (pod,node))`, "{{pod}} - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("ovs-master CPU Usage", "percent",
+		WithPanel(genericLegendTimeSeries("ovs-master CPU Usage", "percent",
 			dashboard.GridPos{X: 0, Y: 40, W: 12, H: 8},
 			promQuery(`irate(container_cpu_usage_seconds_total{id=~"/.*/ovs-vswitchd.service", node=~"$_master_node"}[$interval])*100`, "OVS CPU - {{ node }}"),
 			promQuery(`irate(container_cpu_usage_seconds_total{id=~"/.*/ovsdb-server.service", node=~"$_master_node"}[$interval])*100`, "OVS DB CPU - {{ node }}"),
 		)).
-		WithPanel(ocpGenericLegend("ovs-master Memory Usage", "bytes",
+		WithPanel(genericLegendTimeSeries("ovs-master Memory Usage", "bytes",
 			dashboard.GridPos{X: 12, Y: 40, W: 12, H: 8},
 			promQuery(`container_memory_rss{id=~"/.*/ovs-vswitchd.service", node=~"$_master_node"}`, "OVS Memory - {{ node }}"),
 			promQuery(`container_memory_rss{id=~"/.*/ovsdb-server.service", node=~"$_master_node"}`, "OVS DB Memory - {{ node }}"),
 		)).
-		WithPanel(ocpGenericLegend("ovs-worker CPU Usage", "percent",
+		WithPanel(genericLegendTimeSeries("ovs-worker CPU Usage", "percent",
 			dashboard.GridPos{X: 0, Y: 48, W: 12, H: 8},
 			promQuery(`irate(container_cpu_usage_seconds_total{id=~"/.*/ovs-vswitchd.service", node=~"$_worker_node"}[$interval])*100`, "OVS CPU - {{ node }}"),
 			promQuery(`irate(container_cpu_usage_seconds_total{id=~"/.*/ovsdb-server.service", node=~"$_worker_node"}[$interval])*100`, "OVS DB CPU - {{ node }}"),
 		)).
-		WithPanel(ocpGenericLegend("ovs-worker Memory Usage", "bytes",
+		WithPanel(genericLegendTimeSeries("ovs-worker Memory Usage", "bytes",
 			dashboard.GridPos{X: 12, Y: 48, W: 12, H: 8},
 			promQuery(`container_memory_rss{id=~"/.*/ovs-vswitchd.service", node=~"$_worker_node"}`, "OVS Memory - {{ node }}"),
 			promQuery(`container_memory_rss{id=~"/.*/ovsdb-server.service", node=~"$_worker_node"}`, "OVS DB Memory - {{ node }}"),
 		)).
-		WithPanel(ocpGenericLegend("99% Pod Annotation Latency", "s",
+		WithPanel(genericLegendTimeSeries("99% Pod Annotation Latency", "s",
 			dashboard.GridPos{X: 0, Y: 56, W: 8, H: 8},
 			promQuery(`histogram_quantile(0.99, sum by (instance, pod, le) (rate(ovnkube_controller_pod_creation_latency_seconds_bucket[$interval]))) > 0`, "{{ pod }} - {{ instance }}"),
 		)).
-		WithPanel(ocpGenericLegend("99% CNI Request ADD Latency", "s",
+		WithPanel(genericLegendTimeSeries("99% CNI Request ADD Latency", "s",
 			dashboard.GridPos{X: 8, Y: 56, W: 8, H: 8},
 			promQuery(`histogram_quantile(0.99, sum(rate(ovnkube_node_cni_request_duration_seconds_bucket{command="ADD"}[$interval])) by (instance,pod,le)) > 0`, "{{ pod }} - {{ instance }}"),
 		)).
-		WithPanel(ocpGenericLegend("99% CNI Request DEL Latency", "s",
+		WithPanel(genericLegendTimeSeries("99% CNI Request DEL Latency", "s",
 			dashboard.GridPos{X: 16, Y: 56, W: 8, H: 8},
 			promQuery(`histogram_quantile(0.99, sum(rate(ovnkube_node_cni_request_duration_seconds_bucket{command="DEL"}[$interval])) by (instance,pod,le)) > 0`, "{{ pod }} - {{ instance }}"),
 		)).
-		WithPanel(ocpGenericLegend("ovnkube-control-plane CPU Usage", "percent",
+		WithPanel(genericLegendTimeSeries("ovnkube-control-plane CPU Usage", "percent",
 			dashboard.GridPos{X: 0, Y: 64, W: 12, H: 8},
 			promQuery(`sum( irate(container_cpu_usage_seconds_total{pod=~"(ovnkube-master|ovnkube-control-plane).+",namespace="openshift-ovn-kubernetes",container!~"POD|"}[$interval])*100 ) by (pod, node)`, "{{pod}} - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("ovnkube-control-plane Memory Usage", "bytes",
+		WithPanel(genericLegendTimeSeries("ovnkube-control-plane Memory Usage", "bytes",
 			dashboard.GridPos{X: 12, Y: 64, W: 12, H: 8},
 			promQuery(`container_memory_rss{pod=~"(ovnkube-master|ovnkube-control-plane).+",namespace="openshift-ovn-kubernetes",container!~"POD|"}`, "{{pod}} - {{node}}"),
 		))
@@ -387,22 +264,22 @@ func ocpMonitoringStackRow() *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Monitoring stack").
 		Collapsed(true).
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
-		WithPanel(ocpGenericLegend("Prometheus Replica CPU", "percent",
+		WithPanel(genericLegendTimeSeries("Prometheus Replica CPU", "percent",
 			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
 			promQuery(`sum(irate(container_cpu_usage_seconds_total{pod=~"prometheus-k8s-0",namespace!="",name!="",container="prometheus"}[$interval])) by (pod,container,node) * 100`, "{{pod}} - {{node}}"),
 			promQuery(`sum(irate(container_cpu_usage_seconds_total{pod=~"prometheus-k8s-1",namespace!="",name!="",container="prometheus"}[$interval])) by (pod,container,node) * 100`, "{{pod}} - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("Prometheus Replica RSS", "bytes",
+		WithPanel(genericLegendTimeSeries("Prometheus Replica RSS", "bytes",
 			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
 			promQuery(`sum(container_memory_rss{pod="prometheus-k8s-1",namespace!="",name!="",container="prometheus"}) by (pod)`, "{{pod}}"),
 			promQuery(`sum(container_memory_rss{pod="prometheus-k8s-0",namespace!="",name!="",container="prometheus"}) by (pod)`, "{{pod}}"),
 		)).
-		WithPanel(ocpGenericLegend("metrics-server/prom-adapter CPU", "percent",
+		WithPanel(genericLegendTimeSeries("metrics-server/prom-adapter CPU", "percent",
 			dashboard.GridPos{X: 0, Y: 10, W: 12, H: 8},
 			promQuery(`sum(irate(container_cpu_usage_seconds_total{pod=~"metrics-server-.*",namespace!="",name!=""}[$interval])) by (pod,container) * 100`, "{{pod}}"),
 			promQuery(`sum(irate(container_cpu_usage_seconds_total{pod=~"prometheus-adapter-.*",namespace="openshift-monitoring",name!=""}[$interval])) by (pod,container) * 100`, "{{pod}}"),
 		)).
-		WithPanel(ocpGenericLegend("metrics-server/prom-adapter RSS", "bytes",
+		WithPanel(genericLegendTimeSeries("metrics-server/prom-adapter RSS", "bytes",
 			dashboard.GridPos{X: 12, Y: 10, W: 12, H: 8},
 			promQuery(`sum(container_memory_rss{pod=~"metrics-server-.*",namespace!="",name!=""}) by (pod)`, "{{pod}}"),
 			promQuery(`sum(container_memory_rss{pod=~"prometheus-adapter-.*",namespace="openshift-monitoring",name!=""}) by (pod)`, "{{pod}}"),
@@ -414,11 +291,11 @@ func ocpStackroxRow() *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Stackrox").
 		Collapsed(true).
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
-		WithPanel(ocpGenericLegend("Top 25 stackrox container RSS bytes", "bytes",
+		WithPanel(genericLegendTimeSeries("Top 25 stackrox container RSS bytes", "bytes",
 			dashboard.GridPos{X: 0, Y: 2, W: 12, H: 8},
 			promQuery(`topk(25, container_memory_rss{container!="POD",name!="",namespace!="",namespace=~"stackrox"})`, "{{ pod }}: {{ container }}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 25 stackrox container CPU percent", "percent",
+		WithPanel(genericLegendTimeSeries("Top 25 stackrox container CPU percent", "percent",
 			dashboard.GridPos{X: 12, Y: 2, W: 12, H: 8},
 			promQuery(`topk(25, sum(irate(container_cpu_usage_seconds_total{container!="POD",name!="",namespace!="",namespace=~"stackrox"}[$interval])) by (pod,container,namespace,name,service) * 100)`, "{{ pod }}: {{ container }}"),
 		))
@@ -429,27 +306,27 @@ func ocpClusterKubeletRow() *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Cluster Kubelet").
 		Collapsed(true).
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
-		WithPanel(ocpGenericLegend("Top 10 Kubelet CPU usage", "percent",
+		WithPanel(genericLegendTimeSeries("Top 10 Kubelet CPU usage", "percent",
 			dashboard.GridPos{X: 0, Y: 3, W: 12, H: 8},
 			promQuery(`topk(10,irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[$interval])*100 *  on (node) group_left kube_node_role{ role = "worker" })`, "kubelet - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 crio CPU usage", "percent",
+		WithPanel(genericLegendTimeSeries("Top 10 crio CPU usage", "percent",
 			dashboard.GridPos{X: 12, Y: 3, W: 12, H: 8},
 			promQuery(`topk(10,irate(process_cpu_seconds_total{service="kubelet",job="crio"}[$interval])*100 *  on (node) group_left kube_node_role{ role = "worker" })`, "crio - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("Top 10 Kubelet memory usage", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("Top 10 Kubelet memory usage", "bytes",
 			dashboard.GridPos{X: 0, Y: 11, W: 12, H: 8},
 			promQuery(`topk(10,process_resident_memory_bytes{service="kubelet",job="kubelet"} *  on (node) group_left kube_node_role{ role = "worker" })`, "kubelet - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("Top 10 crio memory usage", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("Top 10 crio memory usage", "bytes",
 			dashboard.GridPos{X: 12, Y: 11, W: 12, H: 8},
 			promQuery(`topk(10,process_resident_memory_bytes{service="kubelet",job="crio"} *  on (node) group_left kube_node_role{ role = "worker" })`, "crio - {{node}}"),
 		)).
-		WithPanel(ocpGenericLegend("inodes usage in /run", "percent",
+		WithPanel(genericLegendTimeSeries("inodes usage in /run", "percent",
 			dashboard.GridPos{X: 0, Y: 19, W: 12, H: 8},
 			promQuery(`(1 - node_filesystem_files_free{fstype!="",mountpoint="/run"} / node_filesystem_files{fstype!="",mountpoint="/run"}) * 100`, "{{instance}}"),
 		)).
-		WithPanel(ocpGenericLegendCounterSumRightHand("inodes count in /run", "none",
+		WithPanel(genericLegendCounterSumRightHandTimeSeries("inodes count in /run", "none",
 			dashboard.GridPos{X: 12, Y: 19, W: 12, H: 8},
 			promQuery(`node_filesystem_files{fstype!="",mountpoint="/run"} - node_filesystem_files_free{fstype!="",mountpoint="/run"}`, "{{instance}}"),
 			promQuery(`sum(node_filesystem_files{fstype!="",mountpoint="/run"} - node_filesystem_files_free{fstype!="",mountpoint="/run"})`, "sum"),
@@ -461,70 +338,70 @@ func ocpClusterDetailsRow() *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Cluster Details").
 		Collapsed(true).
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
-		WithPanel(ocpStat("Current Node Count",
+		WithPanel(genericStat("Current Node Count",
 			dashboard.GridPos{X: 0, Y: 4, W: 8, H: 3},
 			promQuery(`sum(kube_node_info{})`, "Number of nodes"),
 			promQuery(`sum(kube_node_status_condition{status="true"}) by (condition) > 0`, "Node: {{ condition }}"),
 		)).
-		WithPanel(ocpStat("Current Namespace Count",
+		WithPanel(genericStat("Current Namespace Count",
 			dashboard.GridPos{X: 8, Y: 4, W: 8, H: 3},
 			promQuery(`sum(kube_namespace_status_phase) by (phase)`, "{{ phase }}"),
 		)).
-		WithPanel(ocpStat("Current Pod Count",
+		WithPanel(genericStat("Current Pod Count",
 			dashboard.GridPos{X: 16, Y: 4, W: 8, H: 3},
 			promQuery(`sum(kube_pod_status_phase{}) by (phase) > 0`, "{{ phase}} Pods"),
 		)).
-		WithPanel(ocpGeneric("Number of nodes", "none",
+		WithPanel(genericTimeSeries("Number of nodes", "none",
 			dashboard.GridPos{X: 0, Y: 12, W: 8, H: 8},
 			promQuery(`sum(kube_node_info{})`, "Number of nodes"),
 			promQuery(`sum(kube_node_status_condition{status="true"}) by (condition) > 0`, "Node: {{ condition }}"),
 		)).
-		WithPanel(ocpGeneric("Namespace count", "none",
+		WithPanel(genericTimeSeries("Namespace count", "none",
 			dashboard.GridPos{X: 8, Y: 12, W: 8, H: 8},
 			promQuery(`sum(kube_namespace_status_phase) by (phase) > 0`, "{{ phase }} namespaces"),
 		)).
-		WithPanel(ocpGeneric("Pod count", "none",
+		WithPanel(genericTimeSeries("Pod count", "none",
 			dashboard.GridPos{X: 16, Y: 12, W: 8, H: 8},
 			promQuery(`sum(kube_pod_status_phase{}) by (phase)`, "{{phase}} pods"),
 		)).
-		WithPanel(ocpGeneric("Secret & configmap count", "none",
+		WithPanel(genericTimeSeries("Secret & configmap count", "none",
 			dashboard.GridPos{X: 0, Y: 20, W: 8, H: 8},
 			promQuery(`count(kube_secret_info{})`, "secrets"),
 			promQuery(`count(kube_configmap_info{})`, "Configmaps"),
 		)).
-		WithPanel(ocpGeneric("Deployment count", "none",
+		WithPanel(genericTimeSeries("Deployment count", "none",
 			dashboard.GridPos{X: 8, Y: 20, W: 8, H: 8},
 			promQuery(`count(kube_deployment_labels{})`, "Deployments"),
 		)).
-		WithPanel(ocpGeneric("Services count", "none",
+		WithPanel(genericTimeSeries("Services count", "none",
 			dashboard.GridPos{X: 16, Y: 20, W: 8, H: 8},
 			promQuery(`count(kube_service_info{})`, "Services"),
 		)).
-		WithPanel(ocpGeneric("Routes count", "none",
+		WithPanel(genericTimeSeries("Routes count", "none",
 			dashboard.GridPos{X: 0, Y: 20, W: 8, H: 8},
 			promQuery(`count(openshift_route_info{})`, "Routes"),
 		)).
-		WithPanel(ocpGeneric("Alerts", "none",
+		WithPanel(genericTimeSeries("Alerts", "none",
 			dashboard.GridPos{X: 8, Y: 20, W: 8, H: 8},
 			promQuery(`topk(10,sum(ALERTS{severity!="none"}) by (alertname, severity))`, "{{severity}}: {{alertname}}"),
 		)).
-		WithPanel(ocpGenericLegend("Pod Distribution", "none",
+		WithPanel(genericLegendTimeSeries("Pod Distribution", "none",
 			dashboard.GridPos{X: 16, Y: 20, W: 8, H: 8},
 			promQuery(`count(kube_pod_info{}) by (node)`, "{{ node }}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 container CPU", "percent",
+		WithPanel(genericLegendTimeSeries("Top 10 container CPU", "percent",
 			dashboard.GridPos{X: 0, Y: 28, W: 12, H: 8},
 			promQuery(`topk(10,irate(container_cpu_usage_seconds_total{namespace!="",container!="POD",name!=""}[$interval])*100)`, "{{ namespace }} - {{ name }} - {{ node }}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 container RSS", "bytes",
+		WithPanel(genericLegendTimeSeries("Top 10 container RSS", "bytes",
 			dashboard.GridPos{X: 12, Y: 28, W: 12, H: 8},
 			promQuery(`topk(10, container_memory_rss{namespace!="",container!="POD",name!=""})`, "{{ namespace }} - {{ name }} - {{ node }}"),
 		)).
-		WithPanel(ocpGenericLegend("container RSS system.slice", "bytes",
+		WithPanel(genericLegendTimeSeries("container RSS system.slice", "bytes",
 			dashboard.GridPos{X: 12, Y: 36, W: 12, H: 8},
 			promQuery(`sum by (node)(container_memory_rss{id="/system.slice"})`, "system.slice - {{ node }}"),
 		)).
-		WithPanel(ocpGeneric("Goroutines count", "none",
+		WithPanel(genericTimeSeries("Goroutines count", "none",
 			dashboard.GridPos{X: 0, Y: 36, W: 12, H: 8},
 			promQuery(`topk(10, sum(go_goroutines{}) by (job,instance))`, "{{ job }} - {{ instance }}"),
 		))
@@ -535,15 +412,15 @@ func ocpClusterOperatorsDetailsRow() *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Cluster Operators Details").
 		Collapsed(true).
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
-		WithPanel(ocpStat("Cluster operators overview",
+		WithPanel(genericStat("Cluster operators overview",
 			dashboard.GridPos{X: 0, Y: 4, W: 24, H: 3},
 			promQuery(`sum by (condition)(cluster_operator_conditions{condition!=""})`, "{{ condition }}"),
 		)).
-		WithPanel(ocpGenericLegend("Cluster operators information", "none",
+		WithPanel(genericLegendTimeSeries("Cluster operators information", "none",
 			dashboard.GridPos{X: 0, Y: 4, W: 8, H: 8},
 			promQuery(`cluster_operator_conditions{name!="",reason!=""}`, "{{name}} - {{reason}}"),
 		)).
-		WithPanel(ocpGenericLegend("Cluster operators degraded", "none",
+		WithPanel(genericLegendTimeSeries("Cluster operators degraded", "none",
 			dashboard.GridPos{X: 8, Y: 4, W: 8, H: 8},
 			promQuery(`cluster_operator_conditions{condition="Degraded",name!="",reason!=""}`, "{{name}} - {{reason}}"),
 		))
@@ -555,11 +432,11 @@ func ocpMasterRow() *dashboard.RowBuilder {
 		Collapsed(true).
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 8}).
 		Repeat("_master_node").
-		WithPanel(ocpGenericLegend("CPU Basic: $_master_node", "percent",
+		WithPanel(genericLegendTimeSeries("CPU Basic: $_master_node", "percent",
 			dashboard.GridPos{X: 0, Y: 1, W: 12, H: 8},
 			promQuery(`sum by (instance, mode)(irate(node_cpu_seconds_total{instance=~"$_master_node",job=~".*"}[$interval])) * 100`, "Busy {{mode}}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("System Memory: $_master_node", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("System Memory: $_master_node", "bytes",
 			dashboard.GridPos{X: 12, Y: 1, W: 12, H: 8},
 			promQuery(`node_memory_Active_bytes{instance=~"$_master_node"}`, "Active"),
 			promQuery(`node_memory_MemTotal_bytes{instance=~"$_master_node"}`, "Total"),
@@ -567,58 +444,58 @@ func ocpMasterRow() *dashboard.RowBuilder {
 			promQuery(`node_memory_MemAvailable_bytes{instance=~"$_master_node"}`, "Available"),
 			promQuery(`(node_memory_MemTotal_bytes{instance=~"$_master_node"} - (node_memory_MemFree_bytes{instance=~"$_master_node"} + node_memory_Buffers_bytes{instance=~"$_master_node"} +  node_memory_Cached_bytes{instance=~"$_master_node"}))`, "Used"),
 		)).
-		WithPanel(ocpGenericLegend("Disk throughput: $_master_node", "Bps",
+		WithPanel(genericLegendTimeSeries("Disk throughput: $_master_node", "Bps",
 			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 8},
 			promQuery(`rate(node_disk_read_bytes_total{device=~"$block_device",instance=~"$_master_node"}[$interval])`, "{{ device }} - read"),
 			promQuery(`rate(node_disk_written_bytes_total{device=~"$block_device",instance=~"$_master_node"}[$interval])`, "{{ device }} - write"),
 		)).
-		WithPanel(ocpGenericLegend("Disk IOPS: $_master_node", "iops",
+		WithPanel(genericLegendTimeSeries("Disk IOPS: $_master_node", "iops",
 			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 8},
 			promQuery(`rate(node_disk_reads_completed_total{device=~"$block_device",instance=~"$_master_node"}[$interval])`, "{{ device }} - read"),
 			promQuery(`rate(node_disk_writes_completed_total{device=~"$block_device",instance=~"$_master_node"}[$interval])`, "{{ device }} - write"),
 		)).
-		WithPanel(ocpGenericLegend("Network Utilization: $_master_node", "bps",
+		WithPanel(genericLegendTimeSeries("Network Utilization: $_master_node", "bps",
 			dashboard.GridPos{X: 0, Y: 16, W: 12, H: 8},
 			promQuery(`rate(node_network_receive_bytes_total{instance=~"$_master_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - RX"),
 			promQuery(`rate(node_network_transmit_bytes_total{instance=~"$_master_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - TX"),
 		)).
-		WithPanel(ocpGenericLegend("Network Packets: $_master_node", "pps",
+		WithPanel(genericLegendTimeSeries("Network Packets: $_master_node", "pps",
 			dashboard.GridPos{X: 12, Y: 16, W: 12, H: 8},
 			promQuery(`rate(node_network_receive_packets_total{instance=~"$_master_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - RX"),
 			promQuery(`rate(node_network_transmit_packets_total{instance=~"$_master_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - TX"),
 		)).
-		WithPanel(ocpGenericLegend("Network packets drop: $_master_node", "pps",
+		WithPanel(genericLegendTimeSeries("Network packets drop: $_master_node", "pps",
 			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
 			promQuery(`topk(10, rate(node_network_receive_drop_total{instance=~"$_master_node"}[$interval]))`, "rx-drop-{{ device }}"),
 			promQuery(`topk(10,rate(node_network_transmit_drop_total{instance=~"$_master_node"}[$interval]))`, "tx-drop-{{ device }}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("Conntrack stats: $_master_node", "",
+		WithPanel(genericLegendCounterTimeSeries("Conntrack stats: $_master_node", "",
 			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
 			promQuery(`node_nf_conntrack_entries{instance=~"$_master_node"}`, "conntrack_entries"),
 			promQuery(`node_nf_conntrack_entries_limit{instance=~"$_master_node"}`, "conntrack_limit"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 container CPU: $_master_node", "percent",
+		WithPanel(genericLegendTimeSeries("Top 10 container CPU: $_master_node", "percent",
 			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
 			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container!="POD",name!="",node=~"$_master_node",namespace!="",namespace=~"$namespace"}[$interval])) by (pod,container,namespace,name,service) * 100)`, "{{ pod }}: {{ container }}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("Top 10 container RSS: $_master_node", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("Top 10 container RSS: $_master_node", "bytes",
 			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
 			promQuery(`topk(10, container_memory_rss{container!="POD",name!="",node=~"$_master_node",namespace!="",namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
 		)).
-		WithPanel(ocpGenericLegend("cgroup CPU: $_master_node", "percent",
+		WithPanel(genericLegendTimeSeries("cgroup CPU: $_master_node", "percent",
 			dashboard.GridPos{X: 0, Y: 32, W: 12, H: 8},
 			promQuery(`sum by (id) ( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice", node=~"$_master_node"}[$interval])) * 100`, "{{ id }}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("cgroup RSS: $_master_node", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("cgroup RSS: $_master_node", "bytes",
 			dashboard.GridPos{X: 12, Y: 32, W: 12, H: 8},
 			promQuery(`sum by (id) ( container_memory_rss{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/system.slice/.*.service|/system.slice/systemd-udevd.service|/kubepods.slice", node=~"$_master_node"})`, "{{ id }}"),
 		)).
-		WithPanel(ocpGenericLegend("Pod fs rw rate: $_master_node", "Bps",
+		WithPanel(genericLegendTimeSeries("Pod fs rw rate: $_master_node", "Bps",
 			dashboard.GridPos{X: 0, Y: 32, W: 12, H: 8},
 			promQuery(`sum(rate(container_fs_writes_bytes_total{device!~".+dm.+", node=~"$_master_node", pod!=""}[$interval])) by (device, pod)`, "{{ pod }}: {{ device }} - write"),
 			promQuery(`sum(rate(container_fs_reads_bytes_total{device!~".+dm.+", node=~"$_master_node", pod!=""}[$interval])) by (device, pod)`, "{{ pod }}: {{ device }} - read"),
 		)).
-		WithPanel(ocpGenericLegend("cgroup fs rw rate: $_master_node", "Bps",
+		WithPanel(genericLegendTimeSeries("cgroup fs rw rate: $_master_node", "Bps",
 			dashboard.GridPos{X: 12, Y: 32, W: 12, H: 8},
 			promQuery(`sum(rate(container_fs_writes_bytes_total{device!~".+dm.+", node=~"$_master_node", id =~"/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) by (device, id)`, "{{ id }}: {{ device }} - write"),
 			promQuery(`sum(rate(container_fs_reads_bytes_total{device!~".+dm.+", node=~"$_master_node", id =~"/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) by (device, id)`, "{{ id }}: {{ device }} - read"),
@@ -631,11 +508,11 @@ func ocpWorkerRow() *dashboard.RowBuilder {
 		Collapsed(true).
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 8}).
 		Repeat("_worker_node").
-		WithPanel(ocpGenericLegend("CPU Basic: $_worker_node", "percent",
+		WithPanel(genericLegendTimeSeries("CPU Basic: $_worker_node", "percent",
 			dashboard.GridPos{X: 0, Y: 1, W: 12, H: 8},
 			promQuery(`sum by (instance, mode)(irate(node_cpu_seconds_total{instance=~"$_worker_node",job=~".*"}[$interval])) * 100`, "Busy {{mode}}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("System Memory: $_worker_node", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("System Memory: $_worker_node", "bytes",
 			dashboard.GridPos{X: 12, Y: 1, W: 12, H: 8},
 			promQuery(`node_memory_Active_bytes{instance=~"$_worker_node"}`, "Active"),
 			promQuery(`node_memory_MemTotal_bytes{instance=~"$_worker_node"}`, "Total"),
@@ -643,49 +520,49 @@ func ocpWorkerRow() *dashboard.RowBuilder {
 			promQuery(`node_memory_MemAvailable_bytes{instance=~"$_worker_node"}`, "Available"),
 			promQuery(`(node_memory_MemTotal_bytes{instance=~"$_worker_node"} - (node_memory_MemFree_bytes{instance=~"$_worker_node"} + node_memory_Buffers_bytes{instance=~"$_worker_node"} +  node_memory_Cached_bytes{instance=~"$_worker_node"}))`, "Used"),
 		)).
-		WithPanel(ocpGenericLegend("Disk throughput: $_worker_node", "Bps",
+		WithPanel(genericLegendTimeSeries("Disk throughput: $_worker_node", "Bps",
 			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 8},
 			promQuery(`rate(node_disk_read_bytes_total{device=~"$block_device",instance=~"$_worker_node"}[$interval])`, "{{ device }} - read"),
 			promQuery(`rate(node_disk_written_bytes_total{device=~"$block_device",instance=~"$_worker_node"}[$interval])`, "{{ device }} - write"),
 		)).
-		WithPanel(ocpGenericLegend("Disk IOPS: $_worker_node", "iops",
+		WithPanel(genericLegendTimeSeries("Disk IOPS: $_worker_node", "iops",
 			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 8},
 			promQuery(`rate(node_disk_reads_completed_total{device=~"$block_device",instance=~"$_worker_node"}[$interval])`, "{{ device }} - read"),
 			promQuery(`rate(node_disk_writes_completed_total{device=~"$block_device",instance=~"$_worker_node"}[$interval])`, "{{ device }} - write"),
 		)).
-		WithPanel(ocpGenericLegend("Network Utilization: $_worker_node", "bps",
+		WithPanel(genericLegendTimeSeries("Network Utilization: $_worker_node", "bps",
 			dashboard.GridPos{X: 0, Y: 16, W: 12, H: 8},
 			promQuery(`rate(node_network_receive_bytes_total{instance=~"$_worker_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - RX"),
 			promQuery(`rate(node_network_transmit_bytes_total{instance=~"$_worker_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - TX"),
 		)).
-		WithPanel(ocpGenericLegend("Network Packets: $_worker_node", "pps",
+		WithPanel(genericLegendTimeSeries("Network Packets: $_worker_node", "pps",
 			dashboard.GridPos{X: 12, Y: 16, W: 12, H: 8},
 			promQuery(`rate(node_network_receive_packets_total{instance=~"$_worker_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - RX"),
 			promQuery(`rate(node_network_transmit_packets_total{instance=~"$_worker_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - TX"),
 		)).
-		WithPanel(ocpGenericLegend("Network packets drop: $_worker_node", "pps",
+		WithPanel(genericLegendTimeSeries("Network packets drop: $_worker_node", "pps",
 			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
 			promQuery(`topk(10, rate(node_network_receive_drop_total{instance=~"$_worker_node"}[$interval]))`, "rx-drop-{{ device }}"),
 			promQuery(`topk(10,rate(node_network_transmit_drop_total{instance=~"$_worker_node"}[$interval]))`, "tx-drop-{{ device }}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("Conntrack stats: $_worker_node", "",
+		WithPanel(genericLegendCounterTimeSeries("Conntrack stats: $_worker_node", "",
 			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
 			promQuery(`node_nf_conntrack_entries{instance=~"$_worker_node"}`, "conntrack_entries"),
 			promQuery(`node_nf_conntrack_entries_limit{instance=~"$_worker_node"}`, "conntrack_limit"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 container CPU: $_worker_node", "percent",
+		WithPanel(genericLegendTimeSeries("Top 10 container CPU: $_worker_node", "percent",
 			dashboard.GridPos{X: 0, Y: 32, W: 12, H: 8},
 			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container!="POD",name!="",node=~"$_worker_node",namespace!="",namespace=~"$namespace"}[$interval])) by (pod,container,namespace,name,service) * 100)`, "{{ pod }}: {{ container }}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("Top 10 container RSS: $_worker_node", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("Top 10 container RSS: $_worker_node", "bytes",
 			dashboard.GridPos{X: 12, Y: 32, W: 12, H: 8},
 			promQuery(`topk(10, container_memory_rss{container!="POD",name!="",node=~"$_worker_node",namespace!="",namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
 		)).
-		WithPanel(ocpGenericLegend("cgroup CPU: $_worker_node", "percent",
+		WithPanel(genericLegendTimeSeries("cgroup CPU: $_worker_node", "percent",
 			dashboard.GridPos{X: 0, Y: 40, W: 12, H: 8},
 			promQuery(`sum by (id) ( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice", node=~"$_worker_node"}[$interval])) * 100`, "{{ id }}"),
 		)).
-		WithPanel(ocpGenericLegendCounter("cgroup RSS: $_worker_node", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("cgroup RSS: $_worker_node", "bytes",
 			dashboard.GridPos{X: 12, Y: 40, W: 12, H: 8},
 			promQuery(`sum by (id) ( container_memory_rss{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/system.slice/.*.service|/system.slice/systemd-udevd.service|/kubepods.slice", node=~"$_worker_node"})`, "{{ id }}"),
 		))
@@ -697,11 +574,11 @@ func ocpInfraRow() *dashboard.RowBuilder {
 		Collapsed(true).
 		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 8}).
 		Repeat("_infra_node").
-		WithPanel(ocpGenericLegend("CPU Basic: $_infra_node", "percent",
+		WithPanel(genericLegendTimeSeries("CPU Basic: $_infra_node", "percent",
 			dashboard.GridPos{X: 0, Y: 1, W: 12, H: 8},
 			promQuery(`sum by (instance, mode)(irate(node_cpu_seconds_total{instance=~"$_infra_node",job=~".*"}[$interval])) * 100`, "Busy {{mode}}"),
 		)).
-		WithPanel(ocpGenericLegend("System Memory: $_infra_node", "bytes",
+		WithPanel(genericLegendTimeSeries("System Memory: $_infra_node", "bytes",
 			dashboard.GridPos{X: 12, Y: 1, W: 12, H: 8},
 			promQuery(`node_memory_Active_bytes{instance=~"$_infra_node"}`, "Active"),
 			promQuery(`node_memory_MemTotal_bytes{instance=~"$_infra_node"}`, "Total"),
@@ -709,41 +586,41 @@ func ocpInfraRow() *dashboard.RowBuilder {
 			promQuery(`node_memory_MemAvailable_bytes{instance=~"$_infra_node"}`, "Available"),
 			promQuery(`(node_memory_MemTotal_bytes{instance=~"$_infra_node"} - (node_memory_MemFree_bytes{instance=~"$_infra_node"} + node_memory_Buffers_bytes{instance=~"$_infra_node"} +  node_memory_Cached_bytes{instance=~"$_infra_node"}))`, "Used"),
 		)).
-		WithPanel(ocpGenericLegend("Disk throughput: $_infra_node", "Bps",
+		WithPanel(genericLegendTimeSeries("Disk throughput: $_infra_node", "Bps",
 			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 8},
 			promQuery(`rate(node_disk_read_bytes_total{device=~"$block_device",instance=~"$_infra_node"}[$interval])`, "{{ device }} - read"),
 			promQuery(`rate(node_disk_written_bytes_total{device=~"$block_device",instance=~"$_infra_node"}[$interval])`, "{{ device }} - write"),
 		)).
-		WithPanel(ocpGenericLegend("Disk IOPS: $_infra_node", "iops",
+		WithPanel(genericLegendTimeSeries("Disk IOPS: $_infra_node", "iops",
 			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 8},
 			promQuery(`rate(node_disk_reads_completed_total{device=~"$block_device",instance=~"$_infra_node"}[$interval])`, "{{ device }} - read"),
 			promQuery(`rate(node_disk_writes_completed_total{device=~"$block_device",instance=~"$_infra_node"}[$interval])`, "{{ device }} - write"),
 		)).
-		WithPanel(ocpGenericLegend("Network Utilization: $_infra_node", "bps",
+		WithPanel(genericLegendTimeSeries("Network Utilization: $_infra_node", "bps",
 			dashboard.GridPos{X: 0, Y: 16, W: 12, H: 8},
 			promQuery(`rate(node_network_receive_bytes_total{instance=~"$_infra_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - RX"),
 			promQuery(`rate(node_network_transmit_bytes_total{instance=~"$_infra_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - TX"),
 		)).
-		WithPanel(ocpGenericLegend("Network Packets: $_infra_node", "pps",
+		WithPanel(genericLegendTimeSeries("Network Packets: $_infra_node", "pps",
 			dashboard.GridPos{X: 12, Y: 16, W: 12, H: 8},
 			promQuery(`rate(node_network_receive_packets_total{instance=~"$_infra_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - RX"),
 			promQuery(`rate(node_network_transmit_packets_total{instance=~"$_infra_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - TX"),
 		)).
-		WithPanel(ocpGenericLegend("Network packets drop: $_infra_node", "pps",
+		WithPanel(genericLegendTimeSeries("Network packets drop: $_infra_node", "pps",
 			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
 			promQuery(`topk(10, rate(node_network_receive_drop_total{instance=~"$_infra_node"}[$interval]))`, "rx-drop-{{ device }}"),
 			promQuery(`topk(10,rate(node_network_transmit_drop_total{instance=~"$_infra_node"}[$interval]))`, "tx-drop-{{ device }}"),
 		)).
-		WithPanel(ocpGenericLegend("Conntrack stats: $_infra_node", "",
+		WithPanel(genericLegendTimeSeries("Conntrack stats: $_infra_node", "",
 			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
 			promQuery(`node_nf_conntrack_entries{instance=~"$_infra_node"}`, "conntrack_entries"),
 			promQuery(`node_nf_conntrack_entries_limit{instance=~"$_infra_node"}`, "conntrack_limit"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 container CPU: $_infra_node", "percent",
+		WithPanel(genericLegendTimeSeries("Top 10 container CPU: $_infra_node", "percent",
 			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 8},
 			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container!="POD",name!="",node=~"$_infra_node",namespace!="",namespace=~"$namespace"}[$interval])) by (pod,container,namespace,name,service) * 100)`, "{{ pod }}: {{ container }}"),
 		)).
-		WithPanel(ocpGenericLegend("Top 10 container RSS: $_infra_node", "bytes",
+		WithPanel(genericLegendTimeSeries("Top 10 container RSS: $_infra_node", "bytes",
 			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 8},
 			promQuery(`topk(10, container_memory_rss{container!="POD",name!="",node=~"$_infra_node",namespace!="",namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
 		))

--- a/go/ovn.go
+++ b/go/ovn.go
@@ -1,0 +1,301 @@
+package main
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
+	"github.com/grafana/grafana-foundation-sdk/go/stat"
+	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
+)
+
+func buildOVNDashboard() *dashboard.DashboardBuilder {
+	return dashboard.NewDashboardBuilder("Openshift Networking").
+		Time("now-1h", "now").
+		Timezone("utc").
+		Timepicker(dashboard.NewTimePickerBuilder().
+			RefreshIntervals([]string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}),
+		).
+		Refresh("").
+		Readonly().
+		Tooltip(dashboard.DashboardCursorSyncCrosshair).
+		WithVariable(dashboard.NewDatasourceVariableBuilder("Datasource").
+			Type("prometheus").
+			Regex("").
+			Label("Datasource"),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("_master_node").
+			Label("Master").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(kube_node_role{role="master"}, node)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(true).
+			IncludeAll(false),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("_worker_node").
+			Label("Worker").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(kube_node_role{role=~"work.*"}, node)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(true).
+			IncludeAll(false),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("controlplane_pod").
+			Label("OVNKube-Controlplane").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values({pod=~"ovnkube-control-plane.*", namespace=~"openshift-ovn-kubernetes"}, pod)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(true).
+			IncludeAll(false),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("kubenode_pod").
+			Label("OVNKube-Node").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values({pod=~"ovnkube-node.*", namespace=~"openshift-ovn-kubernetes"}, pod)`)}).
+			Datasource(promDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(true).
+			IncludeAll(false),
+		).
+		WithRow(ovnResourceMonitoringRow()).
+		WithRow(ovnPodStartupLatencyRow()).
+		WithRow(ovnComponentResourceRow()).
+		WithRow(ovnWorkQueueRow())
+}
+
+// timeseries: same base as etcd (line, lineWidth 1, fillOpacity 10, etc.) + calcs [mean, max], table, sortBy Max desc
+func ovnTimeSeries(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	p := timeseries.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		DrawStyle(common.GraphDrawStyleLine).
+		LineInterpolation(common.LineInterpolationLinear).
+		BarAlignment(common.BarAlignmentCenter).
+		LineWidth(1).
+		FillOpacity(10).
+		GradientMode(common.GraphGradientModeNone).
+		SpanNulls(boolPtr(false)).
+		PointSize(5).
+		ShowPoints(common.VisibilityModeNever).
+		Stacking(common.NewStackingConfigBuilder().
+			Mode(common.StackingModeNone),
+		).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderDescending),
+		).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			Placement(common.LegendPlacementBottom).
+			DisplayMode(common.LegendDisplayModeTable).
+			Calcs([]string{"mean", "max"}).
+			SortBy("Max").
+			SortDesc(true),
+		)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}
+
+// stat base for OVN: graphMode area, justifyMode auto, colorMode value, titleSize 12, thresholds color mode
+func ovnStatBase(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *stat.PanelBuilder {
+	p := stat.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		JustifyMode(common.BigValueJustifyModeAuto).
+		GraphMode(common.BigValueGraphModeArea).
+		Text(common.NewVizTextDisplayOptionsBuilder().
+			TitleSize(12),
+		).
+		ColorScheme(dashboard.NewFieldColorBuilder().
+			Mode(dashboard.FieldColorModeIdThresholds),
+		).
+		ColorMode(common.BigValueColorModeValue).
+		ReduceOptions(common.NewReduceDataOptionsBuilder().
+			Calcs([]string{"last"}),
+		)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}
+
+func ovnStatThreshold(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *stat.PanelBuilder {
+	return ovnStatBase(title, unit, gridPos, targets...).
+		TextMode(common.BigValueTextModeName).
+		Thresholds(dashboard.NewThresholdsConfigBuilder().
+			Mode(dashboard.ThresholdsModeAbsolute).
+			Steps([]dashboard.Threshold{
+				{Value: nil, Color: "green"},
+				{Value: cog.ToPtr(0.0), Color: "orange"},
+				{Value: cog.ToPtr(1.0), Color: "green"},
+			}),
+		)
+}
+
+func ovnStatOVNController(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *stat.PanelBuilder {
+	return ovnStatBase(title, unit, gridPos, targets...).
+		TextMode(common.BigValueTextModeAuto).
+		Thresholds(dashboard.NewThresholdsConfigBuilder().
+			Mode(dashboard.ThresholdsModeAbsolute).
+			Steps([]dashboard.Threshold{
+				{Value: nil, Color: "green"},
+			}),
+		)
+}
+
+// Row: OVN Resource Monitoring
+func ovnResourceMonitoringRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("OVN Resource Monitoring").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(ovnStatThreshold("OVNKube Cluster Manager Leader", "none",
+			dashboard.GridPos{X: 0, Y: 0, W: 8, H: 4},
+			promQuery(`ovnkube_clustermanager_leader > 0`, "{{pod}}"),
+		)).
+		WithPanel(ovnStatThreshold("OVN Northd Status", "none",
+			dashboard.GridPos{X: 8, Y: 0, W: 8, H: 4},
+			promQuery(`ovn_northd_status`, "{{pod}}"),
+		)).
+		WithPanel(ovnStatOVNController("OVN Controller Count", "none",
+			dashboard.GridPos{X: 16, Y: 0, W: 8, H: 4},
+			promQuery(`count(ovn_controller_monitor_all) by (namespace)`, ""),
+		)).
+		WithPanel(ovnTimeSeries("OVNKube Control Plane CPU Usage", "percent",
+			dashboard.GridPos{X: 0, Y: 4, W: 12, H: 10},
+			promQuery(`sum( irate(container_cpu_usage_seconds_total{pod=~"(ovnkube-master|ovnkube-control-plane).+",namespace="openshift-ovn-kubernetes",container!~"POD|"}[2m])*100 ) by (pod, node)`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ovnTimeSeries("OVNKube Control Plane Memory Usage", "bytes",
+			dashboard.GridPos{X: 12, Y: 4, W: 12, H: 10},
+			promQuery(`container_memory_rss{pod=~"(ovnkube-master|ovnkube-control-plane).+",namespace="openshift-ovn-kubernetes",container!~"POD|"}`, "{{pod}} - {{node}}"),
+		))
+}
+
+// Row: Pod Startup Latency Breakdown
+func ovnPodStartupLatencyRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("Pod Startup Latency Breakdown").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(ovnTimeSeries("Scheduler Pod Scheduling Duration (P99)", "s",
+			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 10},
+			promQuery(`histogram_quantile(0.99, rate(scheduler_pod_scheduling_sli_duration_seconds_bucket[5m])) > 0`, "{{pod}}"),
+		)).
+		WithPanel(ovnTimeSeries("Pod First Seen to LSP Created Latency (P99)", "s",
+			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 10},
+			promQuery(`histogram_quantile(0.99, sum(rate(ovnkube_controller_pod_first_seen_lsp_created_duration_seconds_bucket[2m])) by (pod, le)) > 0`, "{{pod}}"),
+		)).
+		WithPanel(ovnTimeSeries("Pod Annotation Latency (P99)", "s",
+			dashboard.GridPos{X: 0, Y: 10, W: 12, H: 10},
+			promQuery(`histogram_quantile(0.99, sum by (pod, le) (rate(ovnkube_controller_pod_creation_latency_seconds_bucket[2m]))) > 0`, "{{pod}}"),
+		)).
+		WithPanel(ovnTimeSeries("Port Binding After LSP Creation Latency (P99)", "s",
+			dashboard.GridPos{X: 12, Y: 10, W: 12, H: 10},
+			promQuery(`histogram_quantile(0.99, sum(rate(ovnkube_controller_pod_lsp_created_port_binding_duration_seconds_bucket[2m])) by (pod,le)) > 0`, "{{pod}}"),
+		)).
+		WithPanel(ovnTimeSeries("Port Binding to Chassis Assignment Latency (P99)", "s",
+			dashboard.GridPos{X: 0, Y: 20, W: 12, H: 10},
+			promQuery(`histogram_quantile(0.99, sum(rate(ovnkube_controller_pod_port_binding_port_binding_chassis_duration_seconds_bucket[2m])) by (pod, le)) > 0`, "{{pod}}"),
+		)).
+		WithPanel(ovnTimeSeries("Port Marked As Up (P99)", "s",
+			dashboard.GridPos{X: 12, Y: 20, W: 12, H: 10},
+			promQuery(`histogram_quantile(0.99, sum(rate(ovnkube_controller_pod_port_binding_chassis_port_binding_up_duration_seconds_bucket[2m])) by (pod, le)) > 0`, "{{pod}}"),
+		)).
+		WithPanel(ovnTimeSeries("CNI Request ADD Latency (P99)", "s",
+			dashboard.GridPos{X: 0, Y: 30, W: 12, H: 10},
+			promQuery(`histogram_quantile(0.99, sum(rate(ovnkube_node_cni_request_duration_seconds_bucket{command="ADD"}[2m])) by (pod,le)) > 0`, "{{pod}}"),
+		)).
+		WithPanel(ovnTimeSeries("Network Programming Complete (P99)", "s",
+			dashboard.GridPos{X: 12, Y: 30, W: 12, H: 10},
+			promQuery(`histogram_quantile(0.99, sum(rate(ovnkube_controller_network_programming_duration_seconds_bucket[2m])) by (pod, le)) > 0`, "{{pod}}"),
+		)).
+		WithPanel(ovnTimeSeries("Sync Service Latency", "s",
+			dashboard.GridPos{X: 0, Y: 40, W: 12, H: 10},
+			promQuery(`rate(ovnkube_controller_sync_service_latency_seconds_sum[2m])`, "{{pod}} - Sync service latency"),
+		)).
+		WithPanel(ovnTimeSeries("OVNKube Node Ready Latency", "s",
+			dashboard.GridPos{X: 12, Y: 40, W: 12, H: 10},
+			promQuery(`ovnkube_node_ready_duration_seconds{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container!~"POD|"}`, "{{pod}}"),
+		))
+}
+
+// Row: OVN Component Resource Usage
+func ovnComponentResourceRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("OVN Component Resource Usage").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(ovnTimeSeries("OVNKube Node Pods CPU Usage (Top 10)", "percent",
+			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 10},
+			promQuery(`topk(10, (sum(irate(container_cpu_usage_seconds_total{name!="",container!~"POD|",namespace=~"openshift-ovn-kubernetes", node=~"$_worker_node"}[2m]) * 100) by (pod, namespace, node)) > 0)`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ovnTimeSeries("OVNKube Node Pods Memory Usage (Top 10)", "bytes",
+			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 10},
+			promQuery(`topk(10, sum(container_memory_rss{name!="",container!~"POD|",namespace=~"openshift-ovn-kubernetes", node=~"$_worker_node"}) by (pod, namespace, node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ovnTimeSeries("Northd CPU Usage (Top 10)", "percent",
+			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 10},
+			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container="northd", namespace="openshift-ovn-kubernetes"}[2m])*100) by (pod, node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ovnTimeSeries("Northd Memory Usage (Top 10)", "bytes",
+			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 10},
+			promQuery(`topk(10, sum(container_memory_rss{container="northd", namespace="openshift-ovn-kubernetes"}) by (pod, node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ovnTimeSeries("Sbdb CPU Usage (Top 10)", "percent",
+			dashboard.GridPos{X: 0, Y: 16, W: 12, H: 10},
+			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container="sbdb", namespace="openshift-ovn-kubernetes"}[2m])*100) by (pod, node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ovnTimeSeries("Sbdb Memory Usage (Top 10)", "bytes",
+			dashboard.GridPos{X: 12, Y: 16, W: 12, H: 10},
+			promQuery(`topk(10, sum(container_memory_rss{container="sbdb", namespace="openshift-ovn-kubernetes"}) by (pod, node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ovnTimeSeries("Nbdb CPU Usage (Top 10)", "percent",
+			dashboard.GridPos{X: 0, Y: 24, W: 12, H: 10},
+			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container="nbdb", namespace="openshift-ovn-kubernetes"}[2m])*100) by (pod, node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ovnTimeSeries("Nbdb Memory Usage (Top 10)", "bytes",
+			dashboard.GridPos{X: 12, Y: 24, W: 12, H: 10},
+			promQuery(`topk(10, sum(container_memory_rss{container="nbdb", namespace="openshift-ovn-kubernetes"}) by (pod, node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ovnTimeSeries("OVNKube Controller CPU Usage (Top 10)", "percent",
+			dashboard.GridPos{X: 0, Y: 32, W: 12, H: 10},
+			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container="ovnkube-controller", namespace="openshift-ovn-kubernetes"}[2m])*100) by (pod, node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ovnTimeSeries("OVNKube Controller Memory Usage (Top 10)", "bytes",
+			dashboard.GridPos{X: 12, Y: 32, W: 12, H: 10},
+			promQuery(`topk(10, sum(container_memory_rss{container="ovnkube-controller", namespace="openshift-ovn-kubernetes"}) by (pod, node))`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ovnTimeSeries("OVN Controller CPU Usage (Top 10)", "percent",
+			dashboard.GridPos{X: 0, Y: 40, W: 12, H: 10},
+			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"}[2m])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
+		)).
+		WithPanel(ovnTimeSeries("OVN Controller Memory Usage (Top 10)", "bytes",
+			dashboard.GridPos{X: 12, Y: 40, W: 12, H: 10},
+			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"}) by (pod,node))`, "{{pod}} - {{node}}"),
+		))
+}
+
+// Row: WorkQueue Monitoring
+func ovnWorkQueueRow() *dashboard.RowBuilder {
+	return dashboard.NewRowBuilder("WorkQueue Monitoring").
+		Collapsed(true).
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 1}).
+		WithPanel(ovnTimeSeries("OVNKube Controller workqueue", "short",
+			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 10},
+			promQuery(`rate(ovnkube_controller_workqueue_adds_total[2m])`, "{{pod}} - Rate of handled adds"),
+		)).
+		WithPanel(ovnTimeSeries("OVNKube Controller workqueue Depth", "short",
+			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 10},
+			promQuery(`ovnkube_controller_workqueue_depth`, "{{pod}} - Depth of workqueue"),
+		)).
+		WithPanel(ovnTimeSeries("OVNKube Controller workqueue duration", "s",
+			dashboard.GridPos{X: 0, Y: 8, W: 12, H: 10},
+			promQuery(`ovnkube_controller_workqueue_longest_running_processor_seconds`, "{{pod}} - Longest processor duration"),
+		)).
+		WithPanel(ovnTimeSeries("OVNKube Controller workqueue - Unfinished", "s",
+			dashboard.GridPos{X: 12, Y: 8, W: 12, H: 10},
+			promQuery(`ovnkube_controller_workqueue_unfinished_work_seconds`, "{{pod}} - Unfinished work duration"),
+		))
+}

--- a/go/prom_panels.go
+++ b/go/prom_panels.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
+	"github.com/grafana/grafana-foundation-sdk/go/stat"
+	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
+)
+
+func promDatasourceRef() common.DataSourceRef {
+	return common.DataSourceRef{
+		Type: cog.ToPtr("prometheus"),
+		Uid:  cog.ToPtr("${Datasource}"),
+	}
+}
+
+func promQuery(expr, legend string) *prometheus.DataqueryBuilder {
+	return prometheus.NewDataqueryBuilder().
+		Expr(expr).
+		LegendFormat(legend).
+		Format(prometheus.PromQueryFormatTimeSeries).
+		IntervalFactor(2)
+}
+
+func intervalOption(val string) dashboard.VariableOption {
+	return dashboard.VariableOption{
+		Text:  dashboard.StringOrArrayOfString{String: &val},
+		Value: dashboard.StringOrArrayOfString{String: &val},
+	}
+}
+
+// Panel type: generic - base timeseries with tooltip multi/desc, legend table mode
+func genericTimeSeries(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	p := timeseries.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		SpanNulls(boolPtr(false)).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderDescending),
+		).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			DisplayMode(common.LegendDisplayModeTable),
+		)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}
+
+// Panel type: genericLegend - extends generic with calcs [mean, min, max], sortBy Max desc, placement bottom
+func genericLegendTimeSeries(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	p := timeseries.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		SpanNulls(boolPtr(false)).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderDescending),
+		).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			DisplayMode(common.LegendDisplayModeTable).
+			Calcs([]string{"mean", "min", "max"}).
+			SortBy("Max").
+			SortDesc(true).
+			Placement(common.LegendPlacementBottom),
+		)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}
+
+// Panel type: genericLegendCounter - extends generic with calcs [first, min, max, last], sortBy Max desc, placement bottom
+func genericLegendCounterTimeSeries(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	p := timeseries.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		SpanNulls(boolPtr(false)).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderDescending),
+		).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			DisplayMode(common.LegendDisplayModeTable).
+			Calcs([]string{"first", "min", "max", "last"}).
+			SortBy("Max").
+			SortDesc(true).
+			Placement(common.LegendPlacementBottom),
+		)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}
+
+// Panel type: genericLegendCounterSumRightHand - extends genericLegendCounter with override for 'sum' series on right axis
+func genericLegendCounterSumRightHandTimeSeries(title, unit string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *timeseries.PanelBuilder {
+	p := genericLegendCounterTimeSeries(title, unit, gridPos, targets...)
+	return p.OverrideByRegexp("sum", []dashboard.DynamicConfigValue{
+		{Id: "custom.axisPlacement", Value: "right"},
+		{Id: "custom.axisLabel", Value: "sum"},
+	})
+}
+
+// Stat panel
+func genericStat(title string, gridPos dashboard.GridPos, targets ...*prometheus.DataqueryBuilder) *stat.PanelBuilder {
+	p := stat.NewPanelBuilder().
+		Title(title).
+		Datasource(promDatasourceRef()).
+		GridPos(gridPos).
+		ReduceOptions(common.NewReduceDataOptionsBuilder().
+			Calcs([]string{"last"}),
+		)
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+	return p
+}

--- a/go/uperf.go
+++ b/go/uperf.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/elasticsearch"
+	"github.com/grafana/grafana-foundation-sdk/go/table"
+	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
+)
+
+func buildUperfDashboard() *dashboard.DashboardBuilder {
+	return dashboard.NewDashboardBuilder("Public - UPerf Results dashboard").
+		Tags([]string{"network", "performance"}).
+		Time("now-1h", "now").
+		Timezone("utc").
+		Timepicker(dashboard.NewTimePickerBuilder().
+			RefreshIntervals([]string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}),
+		).
+		Refresh("").
+		Readonly().
+		Tooltip(dashboard.DashboardCursorSyncCrosshair).
+		WithVariable(dashboard.NewDatasourceVariableBuilder("Datasource").
+			Type("elasticsearch").
+			Regex("/(.*uperf.*)/").
+			Label("uperf-results datasource"),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("uuid").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "uuid.keyword"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("cluster_name").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "cluster_name.keyword"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("user").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "user.keyword"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("iteration").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "iteration"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("server").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "remote_ip.keyword"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("test_type").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "test_type.keyword"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("protocol").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "protocol.keyword"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("message_size").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "message_size"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("threads").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "num_threads"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithPanel(uperfTimeSeries(
+			"UPerf Performance : Throughput per-second", "bps",
+			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 9},
+			uperfThroughputQuery(),
+		)).
+		WithPanel(uperfTimeSeries(
+			"UPerf Performance : Operations per-second", "pps",
+			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 9},
+			uperfOperationsQuery(),
+		)).
+		WithPanel(uperfResultSummaryTable())
+}
+
+const uperfThroughputLuceneQuery = `uuid: $uuid AND cluster_name: $cluster_name AND user: $user AND  iteration: $iteration AND remote_ip: $server AND message_size: $message_size AND test_type: $test_type AND protocol: $protocol AND num_threads: $threads`
+const uperfOperationsLuceneQuery = `uuid: $uuid AND user: $user AND  iteration: $iteration AND remote_ip: $server AND message_size: $message_size AND test_type: $test_type AND protocol: $protocol AND num_threads: $threads`
+const uperfResultsLuceneQuery = `uuid: $uuid AND user: $user AND  iteration: $iteration AND remote_ip: $server AND message_size: $message_size AND test_type: $test_type AND protocol: $protocol AND NOT norm_ops:0`
+
+func uperfThroughputQuery() *elasticsearch.DataqueryBuilder {
+	return elasticsearch.NewDataqueryBuilder().
+		Query(uperfThroughputLuceneQuery).
+		TimeField("uperf_ts").
+		BucketAggs([]elasticsearch.BucketAggregation{
+			dateHistogramBucketAgg("uperf_ts", "2"),
+		}).
+		Metrics([]elasticsearch.MetricAggregation{
+			sumMetricWithScript("norm_byte", "1", "_value * 8"),
+		})
+}
+
+func uperfOperationsQuery() *elasticsearch.DataqueryBuilder {
+	return elasticsearch.NewDataqueryBuilder().
+		Query(uperfOperationsLuceneQuery).
+		TimeField("uperf_ts").
+		BucketAggs([]elasticsearch.BucketAggregation{
+			dateHistogramBucketAgg("uperf_ts", "2"),
+		}).
+		Metrics([]elasticsearch.MetricAggregation{
+			sumMetric("norm_ops", "1"),
+		})
+}
+
+func uperfTimeSeries(title, unit string, gridPos dashboard.GridPos, target *elasticsearch.DataqueryBuilder) *timeseries.PanelBuilder {
+	return timeseries.NewPanelBuilder().
+		Title(title).
+		Datasource(esDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		Transparent(true).
+		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr(true)}).
+		ShowPoints(common.VisibilityModeNever).
+		LineWidth(1).
+		FillOpacity(10).
+		PointSize(5).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			DisplayMode(common.LegendDisplayModeTable).
+			Placement(common.LegendPlacementBottom).
+			Calcs([]string{"mean", "max"}),
+		).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderNone),
+		).
+		WithTarget(target)
+}
+
+func uperfResultSummaryTable() *table.PanelBuilder {
+	return table.NewPanelBuilder().
+		Title("UPerf Result Summary").
+		Datasource(esDatasourceRef()).
+		GridPos(dashboard.GridPos{X: 0, Y: 20, W: 24, H: 18}).
+		Transparent(true).
+		ShowHeader(true).
+		ColorScheme(dashboard.NewFieldColorBuilder().
+			Mode(dashboard.FieldColorModeIdThresholds),
+		).
+		WithTarget(
+			elasticsearch.NewDataqueryBuilder().
+				Query(uperfResultsLuceneQuery).
+				TimeField("uperf_ts").
+				BucketAggs([]elasticsearch.BucketAggregation{
+					termsBucketAgg("test_type.keyword", "3"),
+					termsBucketAgg("protocol.keyword", "4"),
+					termsBucketAgg("num_threads", "5"),
+					termsBucketAgg("message_size", "2"),
+				}).
+				Metrics([]elasticsearch.MetricAggregation{
+					avgMetricWithScript("norm_byte", "1", "_value * 8"),
+					avgMetric("norm_ops", "6"),
+					avgMetric("norm_ltcy", "7"),
+					countMetric("8"),
+				}),
+		).
+		WithTransformation(dashboard.DataTransformerConfig{
+			Id: "seriesToColumns",
+			Options: map[string]any{
+				"reducers": []any{},
+			},
+		}).
+		WithOverride(
+			dashboard.MatcherConfig{Id: "byName", Options: "message_size"},
+			[]dashboard.DynamicConfigValue{
+				{Id: "unit", Value: ""},
+				{Id: "custom.align", Value: nil},
+			},
+		).
+		WithOverride(
+			dashboard.MatcherConfig{Id: "byName", Options: "Average norm_byte"},
+			[]dashboard.DynamicConfigValue{
+				{Id: "unit", Value: "bps"},
+				{Id: "decimals", Value: "2"},
+				{Id: "custom.align", Value: nil},
+			},
+		).
+		WithOverride(
+			dashboard.MatcherConfig{Id: "byName", Options: "Average norm_ops"},
+			[]dashboard.DynamicConfigValue{
+				{Id: "unit", Value: "none"},
+				{Id: "decimals", Value: "0"},
+				{Id: "custom.align", Value: nil},
+			},
+		).
+		WithOverride(
+			dashboard.MatcherConfig{Id: "byName", Options: "Average norm_ltcy"},
+			[]dashboard.DynamicConfigValue{
+				{Id: "unit", Value: "µs"},
+				{Id: "decimals", Value: "2"},
+				{Id: "custom.align", Value: nil},
+			},
+		).
+		WithOverride(
+			dashboard.MatcherConfig{Id: "byName", Options: "Count"},
+			[]dashboard.DynamicConfigValue{
+				{Id: "displayName", Value: "Sample count"},
+				{Id: "unit", Value: "short"},
+				{Id: "decimals", Value: "2"},
+				{Id: "custom.align", Value: nil},
+			},
+		)
+}

--- a/go/uperf.go
+++ b/go/uperf.go
@@ -136,7 +136,7 @@ func uperfTimeSeries(title, unit string, gridPos dashboard.GridPos, target *elas
 		Unit(unit).
 		GridPos(gridPos).
 		Transparent(true).
-		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr(true)}).
+		SpanNulls(boolPtr(true)).
 		ShowPoints(common.VisibilityModeNever).
 		LineWidth(1).
 		FillOpacity(10).

--- a/go/vegeta.go
+++ b/go/vegeta.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/elasticsearch"
+	"github.com/grafana/grafana-foundation-sdk/go/table"
+	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
+)
+
+func buildVegetaDashboard() *dashboard.DashboardBuilder {
+	return dashboard.NewDashboardBuilder("Vegeta Results").
+		Description("Dashboard for Ingress Performance\n").
+		Tags([]string{""}).
+		Time("now-24h", "now").
+		Timezone("utc").
+		Timepicker(dashboard.NewTimePickerBuilder().
+			RefreshIntervals([]string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}),
+		).
+		Refresh("").
+		Readonly().
+		Tooltip(dashboard.DashboardCursorSyncCrosshair).
+		WithVariable(vegetaDatasourceVar()).
+		WithVariable(vegetaQueryVar("uuid", "uuid.keyword", "UUID")).
+		WithVariable(vegetaQueryVar("hostname", "hostname.keyword", "")).
+		WithVariable(vegetaQueryVar("targets", "targets.keyword", "")).
+		WithVariable(vegetaQueryVar("iteration", "iteration", "")).
+		WithPanel(vegetaTimeSeries(
+			"RPS (rate of sent requests per second)", "reqps",
+			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 9},
+			vegetaESAvgQuery("rps", "1"),
+		)).
+		WithPanel(vegetaTimeSeries(
+			"Throughput (rate of successful requests per second)", "reqps",
+			dashboard.GridPos{X: 12, Y: 0, W: 12, H: 9},
+			vegetaESAvgQuery("throughput", "1"),
+		)).
+		WithPanel(vegetaTimeSeries(
+			"Request Latency (observed over given interval)", "µs",
+			dashboard.GridPos{X: 0, Y: 12, W: 12, H: 9},
+			vegetaESAvgQuery("req_latency", "1"),
+			vegetaESAvgQuery("p99_latency", "1"),
+		)).
+		WithPanel(vegetaResultSummaryTable())
+}
+
+func vegetaDatasourceVar() *dashboard.DatasourceVariableBuilder {
+	return dashboard.NewDatasourceVariableBuilder("Datasource").
+		Type("elasticsearch").
+		Regex("/(.*vegeta.*)/").
+		Label("vegeta-results datasource")
+}
+
+func vegetaQueryVar(name, field, label string) *dashboard.QueryVariableBuilder {
+	b := dashboard.NewQueryVariableBuilder(name).
+		Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "` + field + `"}`)}).
+		Datasource(common.DataSourceRef{
+			Type: cog.ToPtr("elasticsearch"),
+			Uid:  cog.ToPtr("${Datasource}"),
+		}).
+		Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+		Multi(false).
+		IncludeAll(true)
+	if label != "" {
+		b = b.Label(label)
+	}
+	return b
+}
+
+func vegetaESLuceneQuery() string {
+	return `uuid: $uuid AND hostname: $hostname AND iteration: $iteration AND targets: "$targets"`
+}
+
+func vegetaDateHistogramBucketAgg() elasticsearch.BucketAggregation {
+	dh, _ := elasticsearch.NewDateHistogramBuilder().
+		Field("timestamp").
+		Id("2").
+		Settings(elasticsearch.NewElasticsearchDateHistogramSettingsBuilder().
+			Interval("auto").
+			MinDocCount("0").
+			TimeZone("utc"),
+		).
+		Build()
+	return elasticsearch.BucketAggregation{DateHistogram: &dh}
+}
+
+func vegetaAvgMetric(field, id string) elasticsearch.MetricAggregation {
+	avg, _ := elasticsearch.NewAverageBuilder().
+		Field(field).
+		Id(id).
+		Build()
+	return elasticsearch.MetricAggregation{Average: &avg}
+}
+
+func vegetaESAvgQuery(field, metricID string) *elasticsearch.DataqueryBuilder {
+	return elasticsearch.NewDataqueryBuilder().
+		Query(vegetaESLuceneQuery()).
+		TimeField("timestamp").
+		BucketAggs([]elasticsearch.BucketAggregation{
+			vegetaDateHistogramBucketAgg(),
+		}).
+		Metrics([]elasticsearch.MetricAggregation{
+			vegetaAvgMetric(field, metricID),
+		})
+}
+
+func esDatasourceRef() common.DataSourceRef {
+	return common.DataSourceRef{
+		Type: cog.ToPtr("elasticsearch"),
+		Uid:  cog.ToPtr("${Datasource}"),
+	}
+}
+
+func vegetaTimeSeries(title, unit string, gridPos dashboard.GridPos, targets ...*elasticsearch.DataqueryBuilder) *timeseries.PanelBuilder {
+	p := timeseries.NewPanelBuilder().
+		Title(title).
+		Datasource(esDatasourceRef()).
+		Unit(unit).
+		GridPos(gridPos).
+		Transparent(true).
+		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr(true)}).
+		ShowPoints(common.VisibilityModeNever).
+		LineWidth(1).
+		FillOpacity(20).
+		PointSize(5).
+		Legend(common.NewVizLegendOptionsBuilder().
+			ShowLegend(true).
+			DisplayMode(common.LegendDisplayModeTable).
+			Placement(common.LegendPlacementBottom).
+			Calcs([]string{"mean", "max"}),
+		).
+		Tooltip(common.NewVizTooltipOptionsBuilder().
+			Mode(common.TooltipDisplayModeMulti).
+			Sort(common.SortOrderNone),
+		)
+
+	for _, t := range targets {
+		p = p.WithTarget(t)
+	}
+
+	return p
+}
+
+func vegetaTermsBucketAgg(field, id string) elasticsearch.BucketAggregation {
+	t, _ := elasticsearch.NewTermsBuilder().
+		Field(field).
+		Id(id).
+		Settings(elasticsearch.NewElasticsearchTermsSettingsBuilder().
+			Order(elasticsearch.TermsOrderDesc).
+			OrderBy("_term").
+			MinDocCount("1").
+			Size("10"),
+		).
+		Build()
+	return elasticsearch.BucketAggregation{Terms: &t}
+}
+
+func vegetaResultSummaryTable() *table.PanelBuilder {
+	return table.NewPanelBuilder().
+		Title("Vegeta Result Summary").
+		Datasource(esDatasourceRef()).
+		GridPos(dashboard.GridPos{X: 0, Y: 24, W: 24, H: 9}).
+		Transparent(true).
+		ShowHeader(true).
+		ColorScheme(dashboard.NewFieldColorBuilder().
+			Mode(dashboard.FieldColorModeIdThresholds),
+		).
+		WithTarget(
+			elasticsearch.NewDataqueryBuilder().
+				Query(vegetaESLuceneQuery()).
+				TimeField("timestamp").
+				BucketAggs([]elasticsearch.BucketAggregation{
+					vegetaTermsBucketAgg("uuid.keyword", "2"),
+					vegetaTermsBucketAgg("targets.keyword", "1"),
+				}).
+				Metrics([]elasticsearch.MetricAggregation{
+					vegetaAvgMetric("rps", "3"),
+					vegetaAvgMetric("throughput", "4"),
+					vegetaAvgMetric("p99_latency", "5"),
+					vegetaAvgMetric("req_latency", "6"),
+					vegetaAvgMetric("bytes_in", "7"),
+					vegetaAvgMetric("bytes_out", "8"),
+				}),
+		).
+		WithTransformation(dashboard.DataTransformerConfig{
+			Id: "seriesToColumns",
+			Options: map[string]any{
+				"reducers": []any{},
+			},
+		}).
+		WithOverride(
+			dashboard.MatcherConfig{Id: "byName", Options: "Average rps"},
+			[]dashboard.DynamicConfigValue{
+				{Id: "unit", Value: "reqps"},
+				{Id: "decimals", Value: "2"},
+				{Id: "custom.align", Value: nil},
+			},
+		).
+		WithOverride(
+			dashboard.MatcherConfig{Id: "byName", Options: "Average throughput"},
+			[]dashboard.DynamicConfigValue{
+				{Id: "unit", Value: "reqps"},
+				{Id: "decimals", Value: "2"},
+				{Id: "custom.align", Value: nil},
+			},
+		).
+		WithOverride(
+			dashboard.MatcherConfig{Id: "byName", Options: "Average p99_latency"},
+			[]dashboard.DynamicConfigValue{
+				{Id: "unit", Value: "µs"},
+				{Id: "decimals", Value: "2"},
+				{Id: "custom.align", Value: nil},
+			},
+		).
+		WithOverride(
+			dashboard.MatcherConfig{Id: "byName", Options: "Average req_latency"},
+			[]dashboard.DynamicConfigValue{
+				{Id: "unit", Value: "µs"},
+				{Id: "decimals", Value: "2"},
+				{Id: "custom.align", Value: nil},
+			},
+		).
+		WithOverride(
+			dashboard.MatcherConfig{Id: "byName", Options: "Average bytes_in"},
+			[]dashboard.DynamicConfigValue{
+				{Id: "unit", Value: "bps"},
+				{Id: "decimals", Value: "2"},
+				{Id: "custom.align", Value: nil},
+			},
+		).
+		WithOverride(
+			dashboard.MatcherConfig{Id: "byName", Options: "Average bytes_out"},
+			[]dashboard.DynamicConfigValue{
+				{Id: "unit", Value: "bps"},
+				{Id: "decimals", Value: "2"},
+				{Id: "custom.align", Value: nil},
+			},
+		)
+}

--- a/go/vegeta.go
+++ b/go/vegeta.go
@@ -21,11 +21,40 @@ func buildVegetaDashboard() *dashboard.DashboardBuilder {
 		Refresh("").
 		Readonly().
 		Tooltip(dashboard.DashboardCursorSyncCrosshair).
-		WithVariable(vegetaDatasourceVar()).
-		WithVariable(vegetaQueryVar("uuid", "uuid.keyword", "UUID")).
-		WithVariable(vegetaQueryVar("hostname", "hostname.keyword", "")).
-		WithVariable(vegetaQueryVar("targets", "targets.keyword", "")).
-		WithVariable(vegetaQueryVar("iteration", "iteration", "")).
+		WithVariable(dashboard.NewDatasourceVariableBuilder("Datasource").
+			Type("elasticsearch").
+			Regex("/(.*vegeta.*)/").
+			Label("vegeta-results datasource"),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("uuid").
+			Label("UUID").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "uuid.keyword"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("hostname").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "hostname.keyword"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("targets").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "targets.keyword"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
+		WithVariable(dashboard.NewQueryVariableBuilder("iteration").
+			Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "iteration"}`)}).
+			Datasource(esDatasourceRef()).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Multi(false).
+			IncludeAll(true),
+		).
 		WithPanel(vegetaTimeSeries(
 			"RPS (rate of sent requests per second)", "reqps",
 			dashboard.GridPos{X: 0, Y: 0, W: 12, H: 9},
@@ -45,71 +74,18 @@ func buildVegetaDashboard() *dashboard.DashboardBuilder {
 		WithPanel(vegetaResultSummaryTable())
 }
 
-func vegetaDatasourceVar() *dashboard.DatasourceVariableBuilder {
-	return dashboard.NewDatasourceVariableBuilder("Datasource").
-		Type("elasticsearch").
-		Regex("/(.*vegeta.*)/").
-		Label("vegeta-results datasource")
-}
-
-func vegetaQueryVar(name, field, label string) *dashboard.QueryVariableBuilder {
-	b := dashboard.NewQueryVariableBuilder(name).
-		Query(dashboard.StringOrMap{String: cog.ToPtr(`{"find": "terms", "field": "` + field + `"}`)}).
-		Datasource(common.DataSourceRef{
-			Type: cog.ToPtr("elasticsearch"),
-			Uid:  cog.ToPtr("${Datasource}"),
-		}).
-		Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
-		Multi(false).
-		IncludeAll(true)
-	if label != "" {
-		b = b.Label(label)
-	}
-	return b
-}
-
-func vegetaESLuceneQuery() string {
-	return `uuid: $uuid AND hostname: $hostname AND iteration: $iteration AND targets: "$targets"`
-}
-
-func vegetaDateHistogramBucketAgg() elasticsearch.BucketAggregation {
-	dh, _ := elasticsearch.NewDateHistogramBuilder().
-		Field("timestamp").
-		Id("2").
-		Settings(elasticsearch.NewElasticsearchDateHistogramSettingsBuilder().
-			Interval("auto").
-			MinDocCount("0").
-			TimeZone("utc"),
-		).
-		Build()
-	return elasticsearch.BucketAggregation{DateHistogram: &dh}
-}
-
-func vegetaAvgMetric(field, id string) elasticsearch.MetricAggregation {
-	avg, _ := elasticsearch.NewAverageBuilder().
-		Field(field).
-		Id(id).
-		Build()
-	return elasticsearch.MetricAggregation{Average: &avg}
-}
+const vegetaLuceneQuery = `uuid: $uuid AND hostname: $hostname AND iteration: $iteration AND targets: "$targets"`
 
 func vegetaESAvgQuery(field, metricID string) *elasticsearch.DataqueryBuilder {
 	return elasticsearch.NewDataqueryBuilder().
-		Query(vegetaESLuceneQuery()).
+		Query(vegetaLuceneQuery).
 		TimeField("timestamp").
 		BucketAggs([]elasticsearch.BucketAggregation{
-			vegetaDateHistogramBucketAgg(),
+			dateHistogramBucketAgg("timestamp", "2"),
 		}).
 		Metrics([]elasticsearch.MetricAggregation{
-			vegetaAvgMetric(field, metricID),
+			avgMetric(field, metricID),
 		})
-}
-
-func esDatasourceRef() common.DataSourceRef {
-	return common.DataSourceRef{
-		Type: cog.ToPtr("elasticsearch"),
-		Uid:  cog.ToPtr("${Datasource}"),
-	}
 }
 
 func vegetaTimeSeries(title, unit string, gridPos dashboard.GridPos, targets ...*elasticsearch.DataqueryBuilder) *timeseries.PanelBuilder {
@@ -134,26 +110,10 @@ func vegetaTimeSeries(title, unit string, gridPos dashboard.GridPos, targets ...
 			Mode(common.TooltipDisplayModeMulti).
 			Sort(common.SortOrderNone),
 		)
-
 	for _, t := range targets {
 		p = p.WithTarget(t)
 	}
-
 	return p
-}
-
-func vegetaTermsBucketAgg(field, id string) elasticsearch.BucketAggregation {
-	t, _ := elasticsearch.NewTermsBuilder().
-		Field(field).
-		Id(id).
-		Settings(elasticsearch.NewElasticsearchTermsSettingsBuilder().
-			Order(elasticsearch.TermsOrderDesc).
-			OrderBy("_term").
-			MinDocCount("1").
-			Size("10"),
-		).
-		Build()
-	return elasticsearch.BucketAggregation{Terms: &t}
 }
 
 func vegetaResultSummaryTable() *table.PanelBuilder {
@@ -168,19 +128,19 @@ func vegetaResultSummaryTable() *table.PanelBuilder {
 		).
 		WithTarget(
 			elasticsearch.NewDataqueryBuilder().
-				Query(vegetaESLuceneQuery()).
+				Query(vegetaLuceneQuery).
 				TimeField("timestamp").
 				BucketAggs([]elasticsearch.BucketAggregation{
-					vegetaTermsBucketAgg("uuid.keyword", "2"),
-					vegetaTermsBucketAgg("targets.keyword", "1"),
+					termsBucketAgg("uuid.keyword", "2"),
+					termsBucketAgg("targets.keyword", "1"),
 				}).
 				Metrics([]elasticsearch.MetricAggregation{
-					vegetaAvgMetric("rps", "3"),
-					vegetaAvgMetric("throughput", "4"),
-					vegetaAvgMetric("p99_latency", "5"),
-					vegetaAvgMetric("req_latency", "6"),
-					vegetaAvgMetric("bytes_in", "7"),
-					vegetaAvgMetric("bytes_out", "8"),
+					avgMetric("rps", "3"),
+					avgMetric("throughput", "4"),
+					avgMetric("p99_latency", "5"),
+					avgMetric("req_latency", "6"),
+					avgMetric("bytes_in", "7"),
+					avgMetric("bytes_out", "8"),
 				}),
 		).
 		WithTransformation(dashboard.DataTransformerConfig{

--- a/go/vegeta.go
+++ b/go/vegeta.go
@@ -95,7 +95,7 @@ func vegetaTimeSeries(title, unit string, gridPos dashboard.GridPos, targets ...
 		Unit(unit).
 		GridPos(gridPos).
 		Transparent(true).
-		SpanNulls(common.BoolOrFloat64{Bool: cog.ToPtr(true)}).
+		SpanNulls(boolPtr(true)).
 		ShowPoints(common.VisibilityModeNever).
 		LineWidth(1).
 		FillOpacity(20).


### PR DESCRIPTION

## Type of change

- [x] Refactor

## Description

grafonnet development appears to stop at version 11, with grafana proceeding into version 12

Since grafonnet v11 dashboards were unusable, we can skip straight to 12 and also leave python/jsonnet/jb behind.

The syncer sidecar is also reworked into a Job, with the interest of a new user in mind: Create the dashboards on initial load, only.

The pattern of repeatedly syncing dashboards is another deployment model supported by the deployer program. We can provide manifests for both modes, while the image is the same.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
* Comparing rendered JSON from grafonnet and sdk for differences.
* Deploying go dashboards and manually review to ensure all looks as expected
* build and push images to quay to ensure syncer behavior works: (quay link TBD)
* ./dittybopper/deploy.sh in local kind cluster

## Changelog:
- **Add Go dashboard builder using grafana-foundation-sdk**
- **Update go gitignore**
- **Add UPerf dashboard and extract shared ES helpers**
- **Add OCP Performance dashboard migration to Go**
- **Add CLAUDE.md with project context for Go dashboard migration**
- **Add etcd dashboard and boolPtr helper**
- **Add OVN and API Performance Overview dashboard migrations**
- **Add Go deployer to replace Python syncer**
- **Use deterministic UID for deployed dashboards**
- **Deploy one-shot by default, skip existing dashboards**
- **Use K8s Job for dashboard deploy, exit on errors**
- **Fix panel ordering in collapsed rows (SDK gridPos Y:0 bug)**
- **Move less commonly used stackrox row to the bottom**
