### PR TITLE
Metrics profile generator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,23 +7,63 @@ This repo defines Grafana dashboards for performance testing (OpenShift, network
 ## Go Migration (`go/` directory)
 
 ### Structure
-- `go/main.go` — Entry point with dashboard registry (`[]dashboardDef{name, category, builderFunc}`). Writes JSON to `go/rendered/<category>/<name>.json`.
-- `go/helpers.go` — Shared Elasticsearch aggregation helpers only (union type wrappers that are too verbose to inline: `dateHistogramBucketAgg`, `termsBucketAgg`, `avgMetric`, `sumMetric`, `countMetric`, etc.).
-- `go/vegeta.go` — Vegeta Wrapper dashboard (ES queries, 3 timeseries + 1 table).
-- `go/uperf.go` — UPerf dashboard (ES queries with Sum/Count metrics and inline scripts).
-- `go/ocp_performance.go` — OpenShift Performance dashboard (Prometheus queries, 10 rows, ~100 panels, stat panels, interval variable, row repeat).
-- `go/go.mod` — Uses local replace directive pointing to `/Users/ancollin/go/src/github.com/grafana/grafana-foundation-sdk/go`.
+
+**Entry point**
+- `go/main.go` — Dashboard registry (`[]dashboardDef`). Renders JSON + YAML profiles. `--merge` flag combines profile files.
+
+**Dashboards** (one file per dashboard)
+- `go/api_performance.go`
+- `go/etcd.go` — Emits `-metrics.yaml` and `-raw-metrics.yaml` via tracker pattern.
+- `go/node.go`
+- `go/ocp_performance.go` — Also emits collected-data variant and both profile types.
+- `go/ovn.go`
+- `go/uperf.go`
+- `go/vegeta.go`
+
+**Tracker system** (profiles generated as build by-product)
+- `go/panel_tracker.go` — `panelTracker` interface + `namedProfile` struct.
+- `go/query_tracker.go` — Registers aggregated PromQL queries; strips Grafana vars; deduplicates.
+- `go/raw_tracker.go` — Extracts raw metric names via regex + PromQL function deny-list; 1:1 entries.
+
+**Utilities**
+- `go/helpers.go` — ES aggregation union-type wrappers (too verbose to inline).
+- `go/merge.go` — Merges + deduplicates metrics-profile YAML files; output sorted by `metricName`.
+- `go/deploy.go`
+
+**Tests**
+- `go/tracker_test.go` — `extractRawMetrics` units; tracker integration tests against OCP dashboard.
+- `go/merge_test.go` — `mergeProfileFiles` units + real-output integration test.
 
 ### Migrated Dashboards
 1. **vegeta-wrapper** (General) — ES/timeseries/table
 2. **uperf-perf** (General) — ES/timeseries/table with Sum metrics and scripts
 3. **ocp-performance** (General) — Prometheus/timeseries/stat/rows with repeat
+4. **ocp-performance-collected** (General) — Same panels but queries use metric names instead of raw PromQL (for use against kube-burner collected data)
+
+### Metrics Profile Generation
+The Go builder is the single source of truth for both dashboard JSON **and** kube-burner metrics-profile YAML. Profiles are emitted as a by-product of building the dashboard — no separate query list to maintain.
+
+`dashboardDef.metricsProfiles` returns `[]namedProfile{suffix, generator}`. The render loop writes `<name><suffix>.yaml` for each. OCP performance emits two profiles:
+- `ocp-performance-metrics.yaml` — aggregated PromQL queries (via `queryTracker`)
+- `ocp-performance-raw-metrics.yaml` — 1:1 raw metric names (via `rawTracker`), for collecting raw data to visualize in the original dashboard
+
+**panelTracker interface** — row builder functions accept `panelTracker` so tracker implementations can be swapped without touching call sites:
+```go
+type panelTracker interface {
+    track(name string, query *mg.Query, legend string) *prometheus.DataqueryBuilder
+    trackRaw(name string, expr string, legend string) *prometheus.DataqueryBuilder
+}
+```
 
 ### Conventions
 - Panel and variable construction stays **inline** in each dashboard file. Do not create helper structs that abstract away the builder pattern.
 - Shared helpers are limited to ES aggregation type wrappers (genuinely verbose due to union type wrapping).
 - Each dashboard file has its own local panel helpers (e.g., `ocpGenericLegend`, `vegetaTimeSeries`) matching the panel variants from the jsonnet assets.
 - Use `make build` (with `source ~/.venv/performance-dashboards/bin/activate`) to build jsonnet dashboards for comparison.
+- Use `t.track(name, query, legend)` for all panel queries that should appear in the metrics profile.
+- Use `promQuery(expr, legend)` only for secondary display-only series (e.g. per-node detail of an already-tracked aggregation, or `topk()` display filters).
+- `topk(N, ...)` panels must use `promQuery` — they are not meaningful collection targets.
+- Track names must be role-agnostic (no `_master`/`_worker`/`_infra` suffix) so query dedup works across repeated row variants.
 
 ### SDK Patterns & Gotchas
 - **Union types are verbose**: `StringOrMap{String: cog.ToPtr("...")}`, `StringOrArrayOfString{String: &val}`, `BoolOrFloat64{Bool: cog.ToPtr(true)}`. This is because the SDK is auto-generated from Grafana's JSON schema.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,47 @@ Dashboards Available after Migration to Grafonnet v10.1.0(latest):
     - [x] Vegeta Dashboard.
     - [x] YCSB Dashboard.
 
+## Go Builder (`go/` directory)
+
+A parallel implementation using the [grafana-foundation-sdk](https://github.com/grafana/grafana-foundation-sdk) Go builders. The Go builder is the single source of truth for both dashboard JSON **and** kube-burner metrics-profile YAML — profiles are generated as a by-product of building the dashboard, with no separate query list to maintain.
+
+```bash
+cd go && go run .
+# Writes to go/rendered/<category>/<name>.json
+# Writes metrics profiles to go/rendered/<category>/<name>-metrics.yaml / <name>-raw-metrics.yaml
+```
+
+### Outputs
+
+| File | Description |
+|------|-------------|
+| `<name>.json` | Rendered Grafana dashboard |
+| `<name>-metrics.yaml` | Aggregated PromQL metrics profile (kube-burner collection) |
+| `<name>-raw-metrics.yaml` | 1:1 raw Prometheus metric names profile |
+| `ocp-performance-collected.json` | OCP dashboard with metric-name queries (for collected data) |
+
+Dashboards with metrics profiles: `ocp-performance`, `etcd-on-cluster-dashboard`.
+
+### Merging profiles
+
+Combine and deduplicate raw-metrics profiles from multiple dashboards:
+
+```bash
+cd go && go run . --merge combined-raw.yaml \
+  rendered/General/ocp-performance-raw-metrics.yaml \
+  rendered/General/etcd-on-cluster-dashboard-raw-metrics.yaml
+```
+
+Output is sorted alphabetically by `metricName`.
+
+### Tests
+
+```bash
+cd go && go test ./...
+```
+
+Tests enforce: no garbage tokens in raw profiles, no Grafana variables in aggregated profiles, merge deduplication and sort order.
+
 ## Dittybopper
 
 Dittybopper is a tool meant to deploy a grafana instance with certain dashboards on top of a running OpenShift 4.X cluster. Find more info [here](./dittybopper/README.md)

--- a/go/etcd.go
+++ b/go/etcd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	mg "github.com/afcollins/metrics-generator/pkg/metrics"
 	"github.com/grafana/grafana-foundation-sdk/go/cog"
 	"github.com/grafana/grafana-foundation-sdk/go/common"
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
@@ -10,6 +11,23 @@ import (
 )
 
 func buildEtcdDashboard() *dashboard.DashboardBuilder {
+	return buildEtcdDash(&queryTracker{})
+}
+
+func buildEtcdProfiles() []namedProfile {
+	agg := &mg.Generator{}
+	buildEtcdDash(&queryTracker{g: agg})
+
+	raw := &mg.Generator{}
+	buildEtcdDash(&rawTracker{g: raw, seen: map[string]struct{}{}})
+
+	return []namedProfile{
+		{"-metrics", agg},
+		{"-raw-metrics", raw},
+	}
+}
+
+func buildEtcdDash(t panelTracker) *dashboard.DashboardBuilder {
 	return dashboard.NewDashboardBuilder("etcd-cluster-info dashboard").
 		Time("now-1h", "now").
 		Timezone("utc").
@@ -25,19 +43,19 @@ func buildEtcdDashboard() *dashboard.DashboardBuilder {
 			Label("Datasource"),
 		).
 		WithVariable(dashboard.NewQueryVariableBuilder("etcd_pod").
-			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(etcd_cluster_version, pod)`)}).
+			Query(t.trackVarQuery(`label_values(etcd_cluster_version, pod)`)).
 			Datasource(promDatasourceRef()).
 			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
 			Multi(true).
 			IncludeAll(true),
 		).
-		WithRow(etcdGeneralResourceUsageRow()).
-		WithRow(etcdCompactDefragRow()).
-		WithRow(etcdWALFsyncRow()).
-		WithRow(etcdBackendCommitRow()).
-		WithRow(etcdNetworkUsageRow()).
-		WithRow(etcdDBInfoRow()).
-		WithRow(etcdGeneralInfoRow())
+		WithRow(etcdGeneralResourceUsageRow(t)).
+		WithRow(etcdCompactDefragRow(t)).
+		WithRow(etcdWALFsyncRow(t)).
+		WithRow(etcdBackendCommitRow(t)).
+		WithRow(etcdNetworkUsageRow(t)).
+		WithRow(etcdDBInfoRow(t)).
+		WithRow(etcdGeneralInfoRow(t))
 }
 
 // base timeseries for etcd panels
@@ -153,168 +171,168 @@ func etcdStatBase(title, unit string, span, height uint32, targets ...*prometheu
 }
 
 // Row: General Resource Usage
-func etcdGeneralResourceUsageRow() *dashboard.RowBuilder {
+func etcdGeneralResourceUsageRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("General Resource Usage").
 		Collapsed(true).
 		WithPanel(etcdGeneralUsageAgg("CPU usage", "percent",
 			12, 8,
-			promQuery(`sum(irate(container_cpu_usage_seconds_total{namespace="openshift-etcd", container="etcd",pod=~"$etcd_pod"}[2m])) by (pod) * 100`, "{{ pod }}"),
+			t.trackRaw("etcdContainerCPU", `sum(irate(container_cpu_usage_seconds_total{namespace="openshift-etcd", container="etcd",pod=~"$etcd_pod"}[2m])) by (pod) * 100`, "{{ pod }}"),
 		)).
 		WithPanel(etcdGeneralUsageAgg("Memory usage", "bytes",
 			12, 8,
-			promQuery(`sum(avg_over_time(container_memory_working_set_bytes{container="",pod!="", namespace=~"openshift-etcd.*",pod=~"$etcd_pod"}[2m])) BY (pod, namespace)`, "{{ pod }}"),
+			t.trackRaw("etcdContainerMemory", `sum(avg_over_time(container_memory_working_set_bytes{container="",pod!="", namespace=~"openshift-etcd.*",pod=~"$etcd_pod"}[2m])) by (pod, namespace)`, "{{ pod }}"),
 		)).
 		WithPanel(etcdGeneralUsageAgg("Disk WAL Sync Duration", "s",
 			12, 8,
-			promQuery(`histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[5m])) by (pod, le))`, "{{pod}} WAL fsync"),
+			t.trackRaw("etcdDiskWALFsyncP99", `histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[5m])) by (pod, le))`, "{{pod}} WAL fsync"),
 		)).
 		WithPanel(etcdGeneralUsageAgg("Disk Backend Sync Duration", "s",
 			12, 8,
-			promQuery(`histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[5m])) by (pod, le))`, "{{pod}} DB fsync"),
+			t.trackRaw("etcdDiskBackendCommitP99", `histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[5m])) by (pod, le))`, "{{pod}} DB fsync"),
 		)).
 		WithPanel(etcdGeneralUsageAgg("Etcd container disk writes", "Bps",
 			12, 8,
-			promQuery(`rate(container_fs_writes_bytes_total{namespace="openshift-etcd",device!~".+dm.+"}[2m])`, "{{ pod }}: {{ device }}"),
+			t.trackRaw("etcdContainerFSWrites", `rate(container_fs_writes_bytes_total{namespace="openshift-etcd",device!~".+dm.+"}[2m])`, "{{ pod }}: {{ device }}"),
 		)).
 		WithPanel(etcdGeneralUsageAgg("DB Size", "bytes",
 			12, 8,
-			promQuery(`etcd_mvcc_db_total_size_in_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{pod}} DB physical size"),
-			promQuery(`etcd_mvcc_db_total_size_in_use_in_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{pod}} DB logical size"),
+			t.trackRaw("etcdMvccDBTotalSize", `etcd_mvcc_db_total_size_in_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{pod}} DB physical size"),
+			t.trackRaw("etcdMvccDBTotalSizeInUse", `etcd_mvcc_db_total_size_in_use_in_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{pod}} DB logical size"),
 		))
 }
 
 // Row: Compact/Defrag Detailed
-func etcdCompactDefragRow() *dashboard.RowBuilder {
+func etcdCompactDefragRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Compact/Defrag Detailed").
 		Collapsed(true).
 		WithPanel(etcdHistogramStatsRightHand("Compaction Duration sum", "none",
 			8, 8, "sum",
-			promQuery(`delta(etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}[1m:30s])/2`, "rate compact sum {{instance}} "),
-			promQuery(`etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "compact sum {{instance}} "),
+			t.trackRaw("etcdCompactionDurationRate", `delta(etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}[1m:30s])/2`, "rate compact sum {{instance}} "),
+			t.trackRaw("etcdCompactionDurationSum", `etcd_debugging_mvcc_db_compaction_total_duration_milliseconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "compact sum {{instance}} "),
 		)).
 		WithPanel(etcdHistogramStatsRightHand("Defrag Duration sum", "none",
 			8, 8, "count",
-			promQuery(`delta(etcd_disk_backend_defrag_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}[1m:30s])/2`, "rate defrag sum {{instance}} "),
-			promQuery(`etcd_disk_backend_defrag_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "defrag sum {{instance}} "),
+			t.trackRaw("etcdDefragDurationRate", `delta(etcd_disk_backend_defrag_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}[1m:30s])/2`, "rate defrag sum {{instance}} "),
+			t.trackRaw("etcdDefragDurationSum", `etcd_disk_backend_defrag_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "defrag sum {{instance}} "),
 		)).
 		WithPanel(etcdHistogramStatsRightHand("vmstat major page faults", "none",
 			8, 8, "count",
-			promQuery(`rate(node_vmstat_pgmajfault[2m])* on (instance) group_left label_replace(kube_node_role{role="control-plane"},"instance","$1","node","(.*)")`, "rate pgmajfault {{instance}} "),
-			promQuery(`node_vmstat_pgmajfault * on (instance) group_left label_replace(kube_node_role{role="control-plane"},"instance","$1","node","(.*)")`, "pgmajfault {{instance}} "),
+			t.trackRaw("nodeVmstatPgMajFaultRate", `rate(node_vmstat_pgmajfault[2m])* on (instance) group_left label_replace(kube_node_role{role="control-plane"},"instance","$1","node","(.*)")`, "rate pgmajfault {{instance}} "),
+			t.trackRaw("nodeVmstatPgMajFault", `node_vmstat_pgmajfault * on (instance) group_left label_replace(kube_node_role{role="control-plane"},"instance","$1","node","(.*)")`, "pgmajfault {{instance}} "),
 		))
 }
 
 // Row: WAL fsync Duration Detailed
-func etcdWALFsyncRow() *dashboard.RowBuilder {
+func etcdWALFsyncRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("WAL fsync Duration Detailed").
 		Collapsed(true).
 		WithPanel(etcdGeneralUsageAgg("WAL fsync Duration p99", "s",
 			8, 8,
-			promQuery(`histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[5m])) by (pod, le))`, "{{pod}} WAL fsync"),
+			t.trackRaw("etcdDiskWALFsyncP99", `histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[5m])) by (pod, le))`, "{{pod}} WAL fsync"),
 		)).
 		WithPanel(etcdHistogramStatsRightHand("WAL fsync Duration sum", "none",
 			8, 8, "sum",
-			promQuery(`irate(etcd_disk_wal_fsync_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "2m irate WAL sum {{instance}} "),
-			promQuery(`etcd_disk_wal_fsync_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "WAL sum {{instance}} "),
+			t.trackRaw("etcdDiskWALFsyncSumRate", `irate(etcd_disk_wal_fsync_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "2m irate WAL sum {{instance}} "),
+			t.trackRaw("etcdDiskWALFsyncSum", `etcd_disk_wal_fsync_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "WAL sum {{instance}} "),
 		)).
 		WithPanel(etcdHistogramStatsRightHand("WAL fsync Duration count", "none",
 			8, 8, "count",
-			promQuery(`irate(etcd_disk_wal_fsync_duration_seconds_count{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "2m irate WAL count {{instance}} "),
-			promQuery(`etcd_disk_wal_fsync_duration_seconds_count{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "WAL count {{instance}} "),
+			t.trackRaw("etcdDiskWALFsyncCountRate", `irate(etcd_disk_wal_fsync_duration_seconds_count{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "2m irate WAL count {{instance}} "),
+			t.trackRaw("etcdDiskWALFsyncCount", `etcd_disk_wal_fsync_duration_seconds_count{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "WAL count {{instance}} "),
 		))
 }
 
 // Row: Backend Commit Duration Detailed
-func etcdBackendCommitRow() *dashboard.RowBuilder {
+func etcdBackendCommitRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Backend Commit Duration Detailed").
 		Collapsed(true).
 		WithPanel(etcdGeneralUsageAgg("Backend Commit Duration", "s",
 			8, 8,
-			promQuery(`histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[5m])) by (pod, le))`, "{{pod}} DB fsync"),
+			t.trackRaw("etcdDiskBackendCommitP99", `histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[5m])) by (pod, le))`, "{{pod}} DB fsync"),
 		)).
 		WithPanel(etcdHistogramStatsRightHand("Backend Commit Duration sum", "none",
 			8, 8, "sum",
-			promQuery(`irate(etcd_disk_backend_commit_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "2m irate WAL sum {{instance}} "),
-			promQuery(`etcd_disk_backend_commit_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "WAL sum {{instance}} "),
+			t.trackRaw("etcdDiskBackendCommitSumRate", `irate(etcd_disk_backend_commit_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "2m irate WAL sum {{instance}} "),
+			t.trackRaw("etcdDiskBackendCommitSum", `etcd_disk_backend_commit_duration_seconds_sum{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "WAL sum {{instance}} "),
 		)).
 		WithPanel(etcdHistogramStatsRightHand("Backend Commit Duration count", "none",
 			8, 8, "count",
-			promQuery(`irate(etcd_disk_backend_commit_duration_seconds_count{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "2m irate WAL count {{instance}} "),
-			promQuery(`etcd_disk_backend_commit_duration_seconds_count{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "WAL count {{instance}} "),
+			t.trackRaw("etcdDiskBackendCommitCountRate", `irate(etcd_disk_backend_commit_duration_seconds_count{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "2m irate WAL count {{instance}} "),
+			t.trackRaw("etcdDiskBackendCommitCount", `etcd_disk_backend_commit_duration_seconds_count{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "WAL count {{instance}} "),
 		))
 }
 
 // Row: Network Usage
-func etcdNetworkUsageRow() *dashboard.RowBuilder {
+func etcdNetworkUsageRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Network Usage").
 		Collapsed(true).
 		WithPanel(etcdGeneralUsageAgg("Container network traffic", "Bps",
 			12, 8,
-			promQuery(`sum(rate(container_network_receive_bytes_total{ namespace=~"openshift-etcd.*"}[2m])) BY (namespace, pod)`, "rx {{ pod }}"),
-			promQuery(`sum(rate(container_network_transmit_bytes_total{ namespace=~"openshift-etcd.*"}[2m])) BY (namespace, pod)`, "tx {{ pod }}"),
+			t.trackRaw("etcdContainerNetworkRx", `sum(rate(container_network_receive_bytes_total{namespace=~"openshift-etcd.*"}[2m])) by (namespace, pod)`, "rx {{ pod }}"),
+			t.trackRaw("etcdContainerNetworkTx", `sum(rate(container_network_transmit_bytes_total{namespace=~"openshift-etcd.*"}[2m])) by (namespace, pod)`, "tx {{ pod }}"),
 		)).
 		WithPanel(etcdGeneralUsageAgg("p99 peer to peer latency", "s",
 			12, 8,
-			promQuery(`histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m]))`, "{{pod}}"),
+			t.trackRaw("etcdNetworkPeerRTTP99", `histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m]))`, "{{pod}}"),
 		)).
 		WithPanel(etcdGeneralUsageAgg("Peer network traffic", "Bps",
 			12, 8,
-			promQuery(`rate(etcd_network_peer_received_bytes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "rx {{pod}} Peer Traffic"),
-			promQuery(`rate(etcd_network_peer_sent_bytes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "tx {{pod}} Peer Traffic"),
+			t.trackRaw("etcdNetworkPeerRx", `rate(etcd_network_peer_received_bytes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "rx {{pod}} Peer Traffic"),
+			t.trackRaw("etcdNetworkPeerTx", `rate(etcd_network_peer_sent_bytes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "tx {{pod}} Peer Traffic"),
 		)).
 		WithPanel(etcdGeneralUsageAgg("gRPC network traffic", "Bps",
 			12, 8,
-			promQuery(`rate(etcd_network_client_grpc_received_bytes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "rx {{pod}}"),
-			promQuery(`rate(etcd_network_client_grpc_sent_bytes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "tx {{pod}}"),
+			t.trackRaw("etcdNetworkGRPCRx", `rate(etcd_network_client_grpc_received_bytes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "rx {{pod}}"),
+			t.trackRaw("etcdNetworkGRPCTx", `rate(etcd_network_client_grpc_sent_bytes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "tx {{pod}}"),
 		)).
 		WithPanel(etcdWithoutCalcsAgg("Active Streams", "",
 			12, 8,
-			promQuery(`sum(grpc_server_started_total{namespace="openshift-etcd",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{namespace="openshift-etcd",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"})`, "Watch Streams"),
-			promQuery(`sum(grpc_server_started_total{namespace="openshift-etcd",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{namespace="openshift-etcd",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"})`, "Lease Streams"),
+			t.trackRaw("etcdActiveWatchStreams", `sum(grpc_server_started_total{namespace="openshift-etcd",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{namespace="openshift-etcd",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"})`, "Watch Streams"),
+			t.trackRaw("etcdActiveLeaseStreams", `sum(grpc_server_started_total{namespace="openshift-etcd",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}) - sum(grpc_server_handled_total{namespace="openshift-etcd",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"})`, "Lease Streams"),
 		)).
 		WithPanel(etcdWithoutCalcsAgg("Snapshot duration", "s",
 			12, 8,
-			promQuery(`sum(rate(etcd_debugging_snap_save_total_duration_seconds_sum{namespace="openshift-etcd"}[2m]))`, "the total latency distributions of save called by snapshot"),
+			t.trackRaw("etcdSnapSaveDuration", `sum(rate(etcd_debugging_snap_save_total_duration_seconds_sum{namespace="openshift-etcd"}[2m]))`, "the total latency distributions of save called by snapshot"),
 		))
 }
 
 // Row: DB Info per Member
-func etcdDBInfoRow() *dashboard.RowBuilder {
+func etcdDBInfoRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("DB Info per Member").
 		Collapsed(true).
 		WithPanel(etcdWithoutCalcsAgg("% DB Space Used", "percent",
 			8, 8,
-			promQuery(`(etcd_mvcc_db_total_size_in_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"} / etcd_server_quota_backend_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"})*100`, "{{pod}}"),
+			t.trackRaw("etcdDBSpaceUsedPct", `(etcd_mvcc_db_total_size_in_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"} / etcd_server_quota_backend_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"})*100`, "{{pod}}"),
 		)).
 		WithPanel(etcdWithoutCalcsAgg("DB Left capacity (with fragmented space)", "bytes",
 			8, 8,
-			promQuery(`etcd_server_quota_backend_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"} - etcd_mvcc_db_total_size_in_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{pod}}"),
+			t.trackRaw("etcdDBLeftCapacity", `etcd_server_quota_backend_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"} - etcd_mvcc_db_total_size_in_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{pod}}"),
 		)).
 		WithPanel(etcdWithoutCalcsAgg("DB Size Limit (Backend-bytes)", "bytes",
 			8, 8,
-			promQuery(`etcd_server_quota_backend_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod }} Quota Bytes"),
+			t.trackRaw("etcdServerQuotaBackendBytes", `etcd_server_quota_backend_bytes{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod }} Quota Bytes"),
 		))
 }
 
 // Row: General Info
-func etcdGeneralInfoRow() *dashboard.RowBuilder {
+func etcdGeneralInfoRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("General Info").
 		Collapsed(true).
 		WithPanel(etcdGeneralInfo("Raft Proposals", "",
 			12, 8,
-			promQuery(`sum(rate(etcd_server_proposals_failed_total{namespace="openshift-etcd"}[2m]))`, "Proposal Failure Rate"),
-			promQuery(`sum(etcd_server_proposals_pending{namespace="openshift-etcd"})`, "Proposal Pending Total"),
-			promQuery(`sum(rate(etcd_server_proposals_committed_total{namespace="openshift-etcd"}[2m]))`, "Proposal Commit Rate"),
-			promQuery(`sum(rate(etcd_server_proposals_applied_total{namespace="openshift-etcd"}[2m]))`, "Proposal Apply Rate"),
+			t.trackRaw("etcdServerProposalsFailed", `sum(rate(etcd_server_proposals_failed_total{namespace="openshift-etcd"}[2m]))`, "Proposal Failure Rate"),
+			t.trackRaw("etcdServerProposalsPending", `sum(etcd_server_proposals_pending{namespace="openshift-etcd"})`, "Proposal Pending Total"),
+			t.trackRaw("etcdServerProposalsCommitted", `sum(rate(etcd_server_proposals_committed_total{namespace="openshift-etcd"}[2m]))`, "Proposal Commit Rate"),
+			t.trackRaw("etcdServerProposalsApplied", `sum(rate(etcd_server_proposals_applied_total{namespace="openshift-etcd"}[2m]))`, "Proposal Apply Rate"),
 		)).
 		WithPanel(etcdGeneralInfo("Number of leader changes seen", "",
 			12, 8,
-			promQuery(`sum(rate(etcd_server_leader_changes_seen_total{namespace="openshift-etcd"}[2m]))`, ""),
+			t.trackRaw("etcdServerLeaderChanges", `sum(rate(etcd_server_leader_changes_seen_total{namespace="openshift-etcd"}[2m]))`, ""),
 		)).
 		WithPanel(
 			etcdStatBase("Etcd has a leader?", "none",
 				6, 2,
-				promQuery(`max(etcd_server_has_leader{namespace="openshift-etcd"})`, ""),
+				t.trackRaw("etcdServerHasLeader", `max(etcd_server_has_leader{namespace="openshift-etcd"})`, ""),
 			).
 				ReduceOptions(common.NewReduceDataOptionsBuilder().
 					Calcs([]string{"mean"}),
@@ -332,7 +350,7 @@ func etcdGeneralInfoRow() *dashboard.RowBuilder {
 		WithPanel(
 			etcdStatBase("Total number of failed proposals seen", "none",
 				6, 2,
-				promQuery(`max(etcd_server_proposals_committed_total{namespace="openshift-etcd"})`, ""),
+				t.trackRaw("etcdServerProposalsCommittedTotal", `max(etcd_server_proposals_committed_total{namespace="openshift-etcd"})`, ""),
 			).
 				ReduceOptions(common.NewReduceDataOptionsBuilder().
 					Calcs([]string{"mean"}),
@@ -349,29 +367,29 @@ func etcdGeneralInfoRow() *dashboard.RowBuilder {
 		).
 		WithPanel(etcdGeneralInfo("Keys", "short",
 			12, 8,
-			promQuery(`etcd_debugging_mvcc_keys_total{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod }} Num keys"),
+			t.trackRaw("etcdDebuggingMvccKeys", `etcd_debugging_mvcc_keys_total{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod }} Num keys"),
 		)).
 		WithPanel(etcdGeneralInfo("Leader Elections Per Day", "short",
 			12, 6,
-			promQuery(`changes(etcd_server_leader_changes_seen_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[1d])`, "{{instance}} Total Leader Elections Per Day"),
+			t.trackRaw("etcdLeaderElectionsPerDay", `changes(etcd_server_leader_changes_seen_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[1d])`, "{{instance}} Total Leader Elections Per Day"),
 		)).
 		WithPanel(etcdGeneralInfo("Slow Operations", "ops",
 			12, 8,
-			promQuery(`delta(etcd_server_slow_apply_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "{{ pod }} slow applies"),
-			promQuery(`delta(etcd_server_slow_read_indexes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "{{ pod }} slow read indexes"),
+			t.trackRaw("etcdSlowApply", `delta(etcd_server_slow_apply_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "{{ pod }} slow applies"),
+			t.trackRaw("etcdSlowReadIndexes", `delta(etcd_server_slow_read_indexes_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "{{ pod }} slow read indexes"),
 		)).
 		WithPanel(etcdGeneralInfo("Key Operations", "ops",
 			12, 8,
-			promQuery(`rate(etcd_mvcc_put_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "{{ pod }} puts/s"),
-			promQuery(`rate(etcd_mvcc_delete_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "{{ pod }} deletes/s"),
+			t.trackRaw("etcdMvccPuts", `rate(etcd_mvcc_put_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "{{ pod }} puts/s"),
+			t.trackRaw("etcdMvccDeletes", `rate(etcd_mvcc_delete_total{namespace="openshift-etcd",pod=~"$etcd_pod"}[2m])`, "{{ pod }} deletes/s"),
 		)).
 		WithPanel(etcdGeneralCounter("Heartbeat Failures", "short",
 			12, 8,
-			promQuery(`etcd_server_heartbeat_send_failures_total{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod }} heartbeat failures"),
-			promQuery(`etcd_server_health_failures{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod }} health failures"),
+			t.trackRaw("etcdServerHeartbeatFailures", `etcd_server_heartbeat_send_failures_total{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod }} heartbeat failures"),
+			t.trackRaw("etcdServerHealthFailures", `etcd_server_health_failures{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod }} health failures"),
 		)).
 		WithPanel(etcdGeneralInfo("Compacted Keys", "short",
 			12, 8,
-			promQuery(`etcd_debugging_mvcc_db_compaction_keys_total{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod  }} keys compacted"),
+			t.trackRaw("etcdDebuggingCompactionKeys", `etcd_debugging_mvcc_db_compaction_keys_total{namespace="openshift-etcd",pod=~"$etcd_pod"}`, "{{ pod  }} keys compacted"),
 		))
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,8 +1,11 @@
 module github.com/cloud-bulldozer/performance-dashboards
 
-go 1.21
+go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-foundation-sdk/go v0.0.12
+	github.com/afcollins/metrics-generator v0.0.0
 )
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go/go.mod
+++ b/go/go.mod
@@ -3,9 +3,9 @@ module github.com/cloud-bulldozer/performance-dashboards
 go 1.25.8
 
 require (
+	github.com/afcollins/metrics-generator v0.0.1
 	github.com/google/uuid v1.6.0
 	github.com/grafana/grafana-foundation-sdk/go v0.0.12
-	github.com/afcollins/metrics-generator v0.0.0
 )
 
 require gopkg.in/yaml.v3 v3.0.1

--- a/go/go.sum
+++ b/go/go.sum
@@ -2,3 +2,7 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grafana/grafana-foundation-sdk/go v0.0.12 h1:ggGWIJ3ylX16/xtAYlVi1TtUdv+mybYPusOmi1x35kg=
 github.com/grafana/grafana-foundation-sdk/go v0.0.12/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,3 +1,5 @@
+github.com/afcollins/metrics-generator v0.0.1 h1:UtV5ZbkmladTsQPOXz3cuoWyKmsfquOmVDZ/qnvLJLI=
+github.com/afcollins/metrics-generator v0.0.1/go.mod h1:CvjhllzhqloYsuSSFaBZwt4VwFJmQg8gc+6j59V2CWQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grafana/grafana-foundation-sdk/go v0.0.12 h1:ggGWIJ3ylX16/xtAYlVi1TtUdv+mybYPusOmi1x35kg=

--- a/go/helpers.go
+++ b/go/helpers.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/grafana/grafana-foundation-sdk/go/cog"
 	"github.com/grafana/grafana-foundation-sdk/go/common"
 	"github.com/grafana/grafana-foundation-sdk/go/elasticsearch"
@@ -95,4 +98,19 @@ func countMetric(id string) elasticsearch.MetricAggregation {
 		Id(id).
 		Build()
 	return elasticsearch.MetricAggregation{Count: &c}
+}
+
+func createDir(dir string) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "error creating directory %s: %v\n", dir, err)
+		os.Exit(1)
+	}
+}
+
+func writeFile(name string, data []byte) {
+	if err := os.WriteFile(name, data, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "error writing %s: %v\n", name, err)
+		os.Exit(1)
+	}
+	fmt.Printf("wrote %s\n", name)
 }

--- a/go/main.go
+++ b/go/main.go
@@ -13,19 +13,21 @@ import (
 )
 
 type dashboardDef struct {
-	name     string
-	category string
-	builder  func() *dashboard.DashboardBuilder
+	name           string
+	category       string
+	builder        func() *dashboard.DashboardBuilder
+	metricsProfiles func() []namedProfile
 }
 
 var dashboards = []dashboardDef{
-	{"vegeta-wrapper", "General", buildVegetaDashboard},
-	{"uperf-perf", "General", buildUperfDashboard},
-	{"ocp-performance", "General", buildOCPPerformanceDashboard},
-	{"etcd-on-cluster-dashboard", "General", buildEtcdDashboard},
-	{"ovn-dashboard", "General", buildOVNDashboard},
-	{"api-performance-overview", "General", buildAPIPerformanceDashboard},
-	{"node", "General", buildNodeDashboard},
+	{"vegeta-wrapper", "General", buildVegetaDashboard, nil},
+	{"uperf-perf", "General", buildUperfDashboard, nil},
+	{"ocp-performance", "General", buildOCPPerformanceDashboard, buildOCPProfiles},
+	{"ocp-performance-collected", "General", buildOCPCollectedDashboard, nil},
+	{"etcd-on-cluster-dashboard", "General", buildEtcdDashboard, buildEtcdProfiles},
+	{"ovn-dashboard", "General", buildOVNDashboard, nil},
+	{"api-performance-overview", "General", buildAPIPerformanceDashboard, nil},
+	{"node", "General", buildNodeDashboard, nil},
 }
 
 func envDefault(key, fallback string) string {
@@ -36,6 +38,7 @@ func envDefault(key, fallback string) string {
 }
 
 func main() {
+	mergeOutput := flag.String("merge", "", "Merge input profile YAML files into this output path (positional args are inputs)")
 	deployFlag := flag.Bool("deploy", false, "Deploy rendered dashboards to Grafana")
 	loopFlag := flag.Bool("loop", false, "Run deploy in a loop (sidecar mode)")
 	loopInterval := flag.Duration("loop-interval", 60*time.Second, "Interval between deploy loops")
@@ -45,7 +48,14 @@ func main() {
 	gitCommitHash := flag.String("git-commit-hash", envDefault("GIT_COMMIT_HASH", ""), "Git commit hash to append to dashboard tags")
 	flag.Parse()
 
-	// If --input-dir is set, skip rendering and deploy from that directory
+	if *mergeOutput != "" {
+		if err := mergeProfileFiles(flag.Args(), *mergeOutput); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	if *inputDir == "" {
 		renderDashboards(*outputDir)
 	}
@@ -108,7 +118,22 @@ func renderDashboards(outputDir string) {
 			fmt.Fprintf(os.Stderr, "error writing %s: %v\n", outPath, err)
 			os.Exit(1)
 		}
-
 		fmt.Printf("wrote %s\n", outPath)
+
+		if d.metricsProfiles != nil {
+			for _, p := range d.metricsProfiles() {
+				yamlBytes, err := p.g.Generate()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "error generating metrics profile %s for %s/%s: %v\n", p.suffix, d.category, d.name, err)
+					os.Exit(1)
+				}
+				profilePath := filepath.Join(dir, d.name+p.suffix+".yaml")
+				if err := os.WriteFile(profilePath, yamlBytes, 0o644); err != nil {
+					fmt.Fprintf(os.Stderr, "error writing %s: %v\n", profilePath, err)
+					os.Exit(1)
+				}
+				fmt.Printf("wrote %s\n", profilePath)
+			}
+		}
 	}
 }

--- a/go/main.go
+++ b/go/main.go
@@ -7,15 +7,16 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
 )
 
 type dashboardDef struct {
-	name           string
-	category       string
-	builder        func() *dashboard.DashboardBuilder
+	name            string
+	category        string
+	builder         func() *dashboard.DashboardBuilder
 	metricsProfiles func() []namedProfile
 }
 
@@ -133,6 +134,24 @@ func renderDashboards(outputDir string) {
 					os.Exit(1)
 				}
 				fmt.Printf("wrote %s\n", profilePath)
+
+				ruleSuffix := strings.Replace(p.suffix, "-metrics", "-rules", 1)
+				rulesBytes, err := p.g.GenerateRules(d.name)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "error generating rules %s for %s/%s: %v\n", ruleSuffix, d.category, d.name, err)
+					os.Exit(1)
+				}
+				rulesDir := filepath.Join(outputDir, "rules")
+				if err := os.MkdirAll(rulesDir, 0o755); err != nil {
+					fmt.Fprintf(os.Stderr, "error creating directory %s: %v\n", rulesDir, err)
+					os.Exit(1)
+				}
+				rulesPath := filepath.Join(rulesDir, d.name+ruleSuffix+".yaml")
+				if err := os.WriteFile(rulesPath, rulesBytes, 0o644); err != nil {
+					fmt.Fprintf(os.Stderr, "error writing %s: %v\n", rulesPath, err)
+					os.Exit(1)
+				}
+				fmt.Printf("wrote %s\n", rulesPath)
 			}
 		}
 	}

--- a/go/main.go
+++ b/go/main.go
@@ -96,63 +96,37 @@ func main() {
 
 func renderDashboards(outputDir string) {
 	for _, d := range dashboards {
-		built, err := d.builder().Build()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error building dashboard %s/%s: %v\n", d.category, d.name, err)
-			os.Exit(1)
-		}
-
-		jsonBytes, err := json.MarshalIndent(built, "", "  ")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error marshaling dashboard %s/%s: %v\n", d.category, d.name, err)
-			os.Exit(1)
-		}
+		jsonBytes := buildDashboardToJson(d)
 
 		dir := filepath.Join(outputDir, d.category)
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			fmt.Fprintf(os.Stderr, "error creating directory %s: %v\n", dir, err)
-			os.Exit(1)
-		}
-
+		createDir(dir)
 		outPath := filepath.Join(dir, d.name+".json")
-		if err := os.WriteFile(outPath, jsonBytes, 0o644); err != nil {
-			fmt.Fprintf(os.Stderr, "error writing %s: %v\n", outPath, err)
-			os.Exit(1)
-		}
-		fmt.Printf("wrote %s\n", outPath)
+		writeFile(outPath, jsonBytes)
 
 		if d.metricsProfiles != nil {
 			for _, p := range d.metricsProfiles() {
-				yamlBytes, err := p.g.Generate()
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "error generating metrics profile %s for %s/%s: %v\n", p.suffix, d.category, d.name, err)
-					os.Exit(1)
-				}
-				profilePath := filepath.Join(dir, d.name+p.suffix+".yaml")
-				if err := os.WriteFile(profilePath, yamlBytes, 0o644); err != nil {
-					fmt.Fprintf(os.Stderr, "error writing %s: %v\n", profilePath, err)
-					os.Exit(1)
-				}
-				fmt.Printf("wrote %s\n", profilePath)
+				metricProfilesDir := filepath.Join(outputDir, "metrics")
+				createDir(metricProfilesDir)
+				writeFile(filepath.Join(metricProfilesDir, d.name+p.suffix+".yaml"), p.g.Generate())
 
 				ruleSuffix := strings.Replace(p.suffix, "-metrics", "-rules", 1)
-				rulesBytes, err := p.g.GenerateRules(d.name)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "error generating rules %s for %s/%s: %v\n", ruleSuffix, d.category, d.name, err)
-					os.Exit(1)
-				}
 				rulesDir := filepath.Join(outputDir, "rules")
-				if err := os.MkdirAll(rulesDir, 0o755); err != nil {
-					fmt.Fprintf(os.Stderr, "error creating directory %s: %v\n", rulesDir, err)
-					os.Exit(1)
-				}
-				rulesPath := filepath.Join(rulesDir, d.name+ruleSuffix+".yaml")
-				if err := os.WriteFile(rulesPath, rulesBytes, 0o644); err != nil {
-					fmt.Fprintf(os.Stderr, "error writing %s: %v\n", rulesPath, err)
-					os.Exit(1)
-				}
-				fmt.Printf("wrote %s\n", rulesPath)
+				createDir(rulesDir)
+				writeFile(filepath.Join(rulesDir, d.name+ruleSuffix+".yaml"), p.g.GenerateRules(d.name))
 			}
 		}
 	}
+}
+
+func buildDashboardToJson(d dashboardDef) []byte {
+	built, err := d.builder().Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error building dashboard %s/%s: %v\n", d.category, d.name, err)
+	}
+
+	jsonBytes, err := json.MarshalIndent(built, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error marshaling dashboard %s/%s: %v\n", d.category, d.name, err)
+	}
+	return jsonBytes
 }

--- a/go/merge.go
+++ b/go/merge.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+type profileEntry struct {
+	Query        string `yaml:"query"`
+	MetricName   string `yaml:"metricName"`
+	Instant      bool   `yaml:"instant,omitempty"`
+	CaptureStart bool   `yaml:"captureStart,omitempty"`
+}
+
+// mergeProfileFiles merges and deduplicates metrics profile YAML files.
+// Deduplication key is metricName. Output is sorted alphabetically.
+func mergeProfileFiles(inputs []string, output string) error {
+	if len(inputs) == 0 {
+		return fmt.Errorf("no input files specified")
+	}
+
+	seen := map[string]struct{}{}
+	var merged []profileEntry
+
+	for _, path := range inputs {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		var entries []profileEntry
+		if err := yaml.Unmarshal(data, &entries); err != nil {
+			return fmt.Errorf("parsing %s: %w", path, err)
+		}
+		for _, e := range entries {
+			if _, dup := seen[e.MetricName]; dup {
+				continue
+			}
+			seen[e.MetricName] = struct{}{}
+			merged = append(merged, e)
+		}
+	}
+
+	sort.Slice(merged, func(i, j int) bool {
+		return merged[i].MetricName < merged[j].MetricName
+	})
+
+	out, err := yaml.Marshal(merged)
+	if err != nil {
+		return fmt.Errorf("marshaling: %w", err)
+	}
+	if err := os.WriteFile(output, out, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", output, err)
+	}
+	fmt.Printf("wrote %s (%d entries from %d files)\n", output, len(merged), len(inputs))
+	return nil
+}

--- a/go/merge_test.go
+++ b/go/merge_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func writeProfileFile(t *testing.T, dir string, name string, entries []profileEntry) string {
+	t.Helper()
+	data, err := yaml.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func readMergedFile(t *testing.T, path string) []profileEntry {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var entries []profileEntry
+	if err := yaml.Unmarshal(data, &entries); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return entries
+}
+
+func TestMergeProfileFiles_BasicMerge(t *testing.T) {
+	dir := t.TempDir()
+	a := writeProfileFile(t, dir, "a.yaml", []profileEntry{
+		{Query: "foo", MetricName: "foo"},
+		{Query: "bar", MetricName: "bar"},
+	})
+	b := writeProfileFile(t, dir, "b.yaml", []profileEntry{
+		{Query: "baz", MetricName: "baz"},
+	})
+	out := filepath.Join(dir, "merged.yaml")
+
+	if err := mergeProfileFiles([]string{a, b}, out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := readMergedFile(t, out)
+	if len(got) != 3 {
+		t.Fatalf("want 3 entries, got %d: %v", len(got), got)
+	}
+}
+
+func TestMergeProfileFiles_Deduplicated(t *testing.T) {
+	dir := t.TempDir()
+	a := writeProfileFile(t, dir, "a.yaml", []profileEntry{
+		{Query: "foo", MetricName: "foo"},
+		{Query: "bar", MetricName: "bar"},
+	})
+	b := writeProfileFile(t, dir, "b.yaml", []profileEntry{
+		{Query: "bar", MetricName: "bar"}, // duplicate
+		{Query: "baz", MetricName: "baz"},
+	})
+	out := filepath.Join(dir, "merged.yaml")
+
+	if err := mergeProfileFiles([]string{a, b}, out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := readMergedFile(t, out)
+	if len(got) != 3 {
+		t.Fatalf("want 3 entries after dedup, got %d: %v", len(got), got)
+	}
+
+	seen := map[string]int{}
+	for _, e := range got {
+		seen[e.MetricName]++
+	}
+	for name, count := range seen {
+		if count > 1 {
+			t.Errorf("metric %q appears %d times (want 1)", name, count)
+		}
+	}
+}
+
+func TestMergeProfileFiles_SortedAlphabetically(t *testing.T) {
+	dir := t.TempDir()
+	a := writeProfileFile(t, dir, "a.yaml", []profileEntry{
+		{Query: "zzz", MetricName: "zzz"},
+		{Query: "aaa", MetricName: "aaa"},
+	})
+	b := writeProfileFile(t, dir, "b.yaml", []profileEntry{
+		{Query: "mmm", MetricName: "mmm"},
+	})
+	out := filepath.Join(dir, "merged.yaml")
+
+	if err := mergeProfileFiles([]string{a, b}, out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := readMergedFile(t, out)
+	want := []string{"aaa", "mmm", "zzz"}
+	for i, e := range got {
+		if e.MetricName != want[i] {
+			t.Errorf("entry[%d] = %q, want %q", i, e.MetricName, want[i])
+		}
+	}
+}
+
+func TestMergeProfileFiles_PreservesInstantAndCaptureStart(t *testing.T) {
+	dir := t.TempDir()
+	a := writeProfileFile(t, dir, "a.yaml", []profileEntry{
+		{Query: "foo", MetricName: "foo", Instant: true, CaptureStart: true},
+	})
+	out := filepath.Join(dir, "merged.yaml")
+
+	if err := mergeProfileFiles([]string{a}, out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := readMergedFile(t, out)
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(got))
+	}
+	if !got[0].Instant {
+		t.Error("Instant field not preserved")
+	}
+	if !got[0].CaptureStart {
+		t.Error("CaptureStart field not preserved")
+	}
+}
+
+func TestMergeProfileFiles_NoInputs(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "merged.yaml")
+
+	if err := mergeProfileFiles(nil, out); err == nil {
+		t.Fatal("expected error for empty inputs, got nil")
+	}
+}
+
+func TestMergeProfileFiles_MissingInput(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "merged.yaml")
+
+	if err := mergeProfileFiles([]string{"/nonexistent/file.yaml"}, out); err == nil {
+		t.Fatal("expected error for missing input file, got nil")
+	}
+}
+
+func TestMergeProfileFiles_RealDashboardOutputs(t *testing.T) {
+	ocpRaw := "rendered/General/ocp-performance-raw-metrics.yaml"
+	etcdRaw := "rendered/General/etcd-on-cluster-dashboard-raw-metrics.yaml"
+	for _, f := range []string{ocpRaw, etcdRaw} {
+		if _, err := os.Stat(f); err != nil {
+			t.Skipf("rendered output not found (%s), run go run . first", f)
+		}
+	}
+
+	out := filepath.Join(t.TempDir(), "combined-raw.yaml")
+	if err := mergeProfileFiles([]string{ocpRaw, etcdRaw}, out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := readMergedFile(t, out)
+	if len(got) == 0 {
+		t.Fatal("merged file is empty")
+	}
+
+	// No duplicates.
+	seen := map[string]int{}
+	for _, e := range got {
+		seen[e.MetricName]++
+	}
+	for name, count := range seen {
+		if count > 1 {
+			t.Errorf("duplicate in merged output: %q appears %d times", name, count)
+		}
+	}
+
+	// Entries from both files must survive.
+	byName := make(map[string]struct{}, len(got))
+	for _, e := range got {
+		byName[e.MetricName] = struct{}{}
+	}
+	mustHave := []string{
+		"container_cpu_usage_seconds_total", // OCP
+		"node_cpu_seconds_total",            // OCP
+		"etcd_server_has_leader",            // etcd
+		"etcd_mvcc_db_total_size_in_bytes",  // etcd
+	}
+	for _, m := range mustHave {
+		if _, ok := byName[m]; !ok {
+			t.Errorf("expected metric %q missing from merged output", m)
+		}
+	}
+}

--- a/go/ocp_performance.go
+++ b/go/ocp_performance.go
@@ -1,11 +1,86 @@
 package main
 
 import (
+	mg "github.com/afcollins/metrics-generator/pkg/metrics"
 	"github.com/grafana/grafana-foundation-sdk/go/cog"
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
 )
 
+const (
+	intervalVar = mg.RateInterval("$interval")
+
+	cgroupIDFilter             = `job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"`
+	cgroupIDFilterWithJournald = `job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/system.slice/.*.service|/system.slice/systemd-udevd.service|/kubepods.slice"`
+
+	fsWriteFilter    = `device!~".+dm.+"`
+	fsReadFilter     = `device!~".+dm.+"`
+	cgroupFSIDFilter = `device!~".+dm.+", id =~"/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"`
+)
+
+func q(metric mg.Metric, filters string) string {
+	return mg.Q(metric, filters).String()
+}
+
 func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
+	return buildOCPDashboard(&queryTracker{})
+}
+
+func buildOCPCollectedDashboard() *dashboard.DashboardBuilder {
+	return buildOCPDashboard(&queryTracker{useMetricNames: true})
+}
+
+func buildOCPProfiles() []namedProfile {
+	agg := &mg.Generator{}
+	buildOCPDashboard(&queryTracker{g: agg})
+
+	raw := &mg.Generator{}
+	buildOCPDashboard(&rawTracker{g: raw, seen: map[string]struct{}{}})
+
+	return []namedProfile{
+		{"-metrics", agg},
+		{"-raw-metrics", raw},
+	}
+}
+
+// ocpDashboardMetrics lists every raw Prometheus metric used in the OCP performance dashboard.
+// Keep in sync with panel queries — enforced by TestOCPDashboardMetricsDeclared.
+var ocpDashboardMetrics = []mg.Metric{
+	mg.MetricContainerCPU,
+	mg.MetricContainerMemoryRSS,
+	mg.MetricContainerFSWrites,
+	mg.MetricNodeCPU,
+	mg.MetricNodeMemoryAvailable,
+	mg.MetricNodeMemoryActive,
+	mg.MetricNodeMemoryTotal,
+	mg.MetricNodeMemoryCached,
+	mg.MetricNodeMemoryFree,
+	mg.MetricNodeDiskRead,
+	mg.MetricNodeDiskWritten,
+	mg.MetricNodeNetworkRx,
+	mg.MetricNodeNetworkTx,
+	mg.MetricNodeNetworkRxDrop,
+	mg.MetricNodeMemoryBuffers,
+	mg.MetricNodeFsFiles,
+	mg.MetricNodeFsFilesFree,
+	mg.MetricNodeNFConntrackEntries,
+	mg.MetricNodeNFConntrackEntriesLimit,
+	mg.MetricNodeNetworkRxPackets,
+	mg.MetricNodeNetworkTxPackets,
+	mg.MetricNodeNetworkTxDrop,
+	mg.MetricContainerFSReads,
+	mg.MetricProcessCPU,
+	mg.MetricProcessMemory,
+	mg.MetricKubeNodeStatusCondition,
+	mg.MetricKubeNamespacePhase,
+	mg.MetricKubePodStatusPhase,
+	mg.MetricKubePodInfo,
+	mg.MetricKubeSecretInfo,
+	mg.MetricKubeConfigmapInfo,
+	mg.MetricKubeServiceInfo,
+	mg.MetricClusterOperatorConditions,
+}
+
+func buildOCPDashboard(t panelTracker) *dashboard.DashboardBuilder {
 	return dashboard.NewDashboardBuilder("Openshift Performance").
 		Description("Performance dashboard for Red Hat Openshift\n").
 		Tags([]string{}).
@@ -22,7 +97,7 @@ func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
 		).
 		WithVariable(dashboard.NewQueryVariableBuilder("_master_node").
 			Label("Master").
-			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(kube_node_role{role="master"}, node)`)}).
+			Query(t.trackVarQuery(`label_values(kube_node_role{role="master"}, node)`)).
 			Datasource(promDatasourceRef()).
 			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
 			Multi(true).
@@ -30,7 +105,7 @@ func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
 		).
 		WithVariable(dashboard.NewQueryVariableBuilder("_worker_node").
 			Label("Worker").
-			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(kube_node_role{role=~"worker"}, node)`)}).
+			Query(t.trackVarQuery(`label_values(kube_node_role{role=~"worker"}, node)`)).
 			Datasource(promDatasourceRef()).
 			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
 			Multi(true).
@@ -38,7 +113,7 @@ func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
 		).
 		WithVariable(dashboard.NewQueryVariableBuilder("_infra_node").
 			Label("Infra").
-			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(kube_node_role{role="infra"}, node)`)}).
+			Query(t.trackVarQuery(`label_values(kube_node_role{role="infra"}, node)`)).
 			Datasource(promDatasourceRef()).
 			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
 			Multi(true).
@@ -46,7 +121,7 @@ func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
 		).
 		WithVariable(dashboard.NewQueryVariableBuilder("namespace").
 			Label("Namespace").
-			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{namespace!~"(cluster-density.*|node-density-.*)"},namespace)`)}).
+			Query(t.trackVarQuery(`label_values(` + q(mg.MetricKubePodInfo, mg.Filters(mg.NSNotRegex("cluster-density.*|node-density-.*"))) + ",namespace)")).
 			Datasource(promDatasourceRef()).
 			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
 			Regex("").
@@ -55,7 +130,7 @@ func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
 		).
 		WithVariable(dashboard.NewQueryVariableBuilder("block_device").
 			Label("Block device").
-			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(node_disk_written_bytes_total, device)`)}).
+			Query(t.trackVarQuery(`label_values(node_disk_written_bytes_total, device)`)).
 			Datasource(promDatasourceRef()).
 			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
 			Regex(`/^(?:(?!dm|rb).)*$/`).
@@ -64,7 +139,7 @@ func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
 		).
 		WithVariable(dashboard.NewQueryVariableBuilder("net_device").
 			Label("Network device").
-			Query(dashboard.StringOrMap{String: cog.ToPtr(`label_values(node_network_receive_bytes_total, device)`)}).
+			Query(t.trackVarQuery(`label_values(node_network_receive_bytes_total, device)`)).
 			Datasource(promDatasourceRef()).
 			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
 			Regex(`/^((br|en|et).*)$/`).
@@ -83,315 +158,574 @@ func buildOCPPerformanceDashboard() *dashboard.DashboardBuilder {
 			}),
 		).
 		// Row: Cluster-at-a-Glance
-		WithRow(ocpClusterAtAGlanceRow()).
+		WithRow(ocpClusterAtAGlanceRow(t)).
 		// Row: OVN
-		WithRow(ocpOVNRow()).
+		WithRow(ocpOVNRow(t)).
 		// Row: Monitoring stack
-		WithRow(ocpMonitoringStackRow()).
+		WithRow(ocpMonitoringStackRow(t)).
 		// Row: Cluster Kubelet
-		WithRow(ocpClusterKubeletRow()).
+		WithRow(ocpClusterKubeletRow(t)).
 		// Row: Cluster Details
-		WithRow(ocpClusterDetailsRow()).
+		WithRow(ocpClusterDetailsRow(t)).
 		// Row: Cluster Operators Details
-		WithRow(ocpClusterOperatorsDetailsRow()).
+		WithRow(ocpClusterOperatorsDetailsRow(t)).
 		// Row: Master
-		WithRow(ocpMasterRow()).
+		WithRow(ocpNodeRow(t, "_master_node", mg.RoleMaster)).
 		// Row: Worker
-		WithRow(ocpWorkerRow()).
+		WithRow(ocpNodeRow(t, "_worker_node", mg.RoleWorker)).
 		// Row: Infra
-		WithRow(ocpInfraRow()).
+		WithRow(ocpNodeRow(t, "_infra_node", mg.RoleInfra)).
 		// Row: Stackrox
-		WithRow(ocpStackroxRow())
+		WithRow(ocpStackroxRow(t))
 }
 
 
 // Row: Cluster-at-a-Glance
-func ocpClusterAtAGlanceRow() *dashboard.RowBuilder {
+func ocpClusterAtAGlanceRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Cluster-at-a-Glance").
 		Collapsed(true).
 		WithPanel(genericLegendTimeSeries("Workers CPU Usage", "percent",
 			12, 8,
-			promQuery(`sum( rate( (node_cpu_seconds_total{ mode != "idle" } * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)") )[$interval:] ) ) by (instance) * 100`, "{{instance}}"),
+			t.track("nodeCPUWorker",
+				mg.Q(mg.MetricNodeCPU, `mode != "idle"`).
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByInstance},
+						mg.NodeRoleLabelReplace(mg.RoleWorker)).
+					RateSubquery(intervalVar).
+					Agg(mg.AggSum, mg.GroupByInstance).
+					Multiply("100"),
+				"{{instance}}"),
 			promQuery("node_cpu_seconds_sum_rate_2m_30s_worker", "{{instance}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Control Plane CPU Usage", "percent",
 			12, 8,
-			promQuery(`sum( rate( (node_cpu_seconds_total{ mode != "idle" } * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)") )[$interval:] ) ) by (instance) * 100`, "{{instance}}"),
+			t.track("nodeCPUControlPlane",
+				mg.Q(mg.MetricNodeCPU, `mode != "idle"`).
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByInstance},
+						mg.NodeRoleLabelReplace("control-plane")).
+					RateSubquery(intervalVar).
+					Agg(mg.AggSum, mg.GroupByInstance).
+					Multiply("100"),
+				"{{instance}}"),
 			promQuery("node_cpu_seconds_sum_rate_2m_30s_master", "{{instance}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Workers Load1", "short",
 			12, 8,
-			promQuery(`node_load1 * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)") `, "{{instance}}"),
+			t.track("nodeLoad1Worker",
+				mg.Raw("node_load1").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByInstance},
+						mg.NodeRoleLabelReplace(mg.RoleWorker)),
+				"{{instance}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Control Plane Load1", "short",
 			12, 8,
-			promQuery(`node_load1 * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)") `, "{{instance}}"),
+			t.track("nodeLoad1ControlPlane",
+				mg.Raw("node_load1").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByInstance},
+						mg.NodeRoleLabelReplace("control-plane")),
+				"{{instance}}"),
 		)).
 		WithPanel(genericLegendCounterSumRightHandTimeSeries("Workers Memory Available", "bytes",
 			12, 8,
-			promQuery(`node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)")`, "{{instance}}"),
-			promQuery(`sum( node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "worker"} , "instance" , "$1" , "node" ,"(.*)") )`, "sum"),
+			t.track("nodeMemoryAvailableWorker",
+				mg.Q(mg.MetricNodeMemoryAvailable, "").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByInstance},
+						mg.NodeRoleLabelReplace(mg.RoleWorker)),
+				"{{instance}}"),
+			t.track("nodeMemoryAvailableWorkerSum",
+				mg.Q(mg.MetricNodeMemoryAvailable, "").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByInstance},
+						mg.NodeRoleLabelReplace(mg.RoleWorker)).
+					Agg(mg.AggSum),
+				"sum"),
 		)).
 		WithPanel(genericLegendCounterSumRightHandTimeSeries("Control Plane Memory Available", "bytes",
 			12, 8,
-			promQuery(`node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)")`, "{{instance}}"),
-			promQuery(`sum( node_memory_MemAvailable_bytes * on (instance) group_left label_replace( kube_node_role{ role = "control-plane"} , "instance" , "$1" , "node" ,"(.*)") )`, "sum"),
+			t.track("nodeMemoryAvailableControlPlane",
+				mg.Q(mg.MetricNodeMemoryAvailable, "").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByInstance},
+						mg.NodeRoleLabelReplace("control-plane")),
+				"{{instance}}"),
+			t.track("nodeMemoryAvailableControlPlaneSum",
+				mg.Q(mg.MetricNodeMemoryAvailable, "").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByInstance},
+						mg.NodeRoleLabelReplace("control-plane")).
+					Agg(mg.AggSum),
+				"sum"),
 		)).
 		WithPanel(genericLegendTimeSeries("Workers CGroup CPU Rate", "percent",
 			12, 8,
-			promQuery(`sum by (id) (( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) * 100 * on (node) group_left kube_node_role{ role = "worker" } )`, "{{id}}"),
+			t.track("cgroupCPUWorker",
+				mg.Q(mg.MetricContainerCPU, cgroupIDFilter).
+					Rate(intervalVar).
+					Multiply("100").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByNode},
+						mg.NodeRoleFilter(mg.RoleWorker)).
+					Agg(mg.AggSum, mg.GroupByID),
+				"{{instance}}"),
 			promQuery(`sum by (id) (container_cpu_usage_seconds_total_cgroup_sum_rate_id_node * on (node) group_left kube_node_role{ role = "worker" })`, "{{id}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Control Plane CGroup CPU Rate", "percent",
 			12, 8,
-			promQuery(`sum by (id) (( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) * 100 * on (node) group_left kube_node_role{ role = "control-plane" } )`, "{{id}}"),
+			t.track("cgroupCPUControlPlane",
+				mg.Q(mg.MetricContainerCPU, cgroupIDFilter).
+					Rate(intervalVar).
+					Multiply("100").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByNode},
+						mg.NodeRoleFilter("control-plane")).
+					Agg(mg.AggSum, mg.GroupByID),
+				"{{instance}}"),
 			promQuery(`sum by (id) (container_cpu_usage_seconds_total_cgroup_sum_rate_id_node * on (node) group_left kube_node_role{ role = "control-plane" })`, "{{id}}"),
 		)).
 		WithPanel(genericLegendCounterTimeSeries("Workers CGroup Memory RSS", "bytes",
 			12, 8,
-			promQuery(`sum by (id) ( container_memory_rss{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"} * on (node) group_left kube_node_role{ role = "worker" } )`, "{{id}}"),
+			t.track("cgroupMemoryRSSWorker",
+				mg.Q(mg.MetricContainerMemoryRSS, cgroupIDFilter).
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByNode},
+						mg.NodeRoleFilter(mg.RoleWorker)).
+					Agg(mg.AggSum, mg.GroupByID),
+				"{{instance}}"),
 			promQuery(`sum by (id) (container_memory_working_set_bytes_cgroup * on (node) group_left kube_node_role{ role = "worker" })`, "{{id}}"),
 		)).
 		WithPanel(genericLegendCounterTimeSeries("Control Plane CGroup Memory RSS", "bytes",
 			12, 8,
-			promQuery(`sum by (id) ( container_memory_rss{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"} * on (node) group_left kube_node_role{ role = "control-plane" } )`, "{{id}}"),
+			t.track("cgroupMemoryRSSControlPlane",
+				mg.Q(mg.MetricContainerMemoryRSS, cgroupIDFilter).
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByNode},
+						mg.NodeRoleFilter("control-plane")).
+					Agg(mg.AggSum, mg.GroupByID),
+				"{{instance}}"),
 			promQuery(`sum by (id) (container_memory_working_set_bytes_cgroup * on (node) group_left kube_node_role{ role = "control-plane" })`, "{{id}}"),
 		)).
 		WithPanel(genericLegendCounterTimeSeries("Workers Container Threads", "short",
 			12, 8,
-			promQuery(`sum by (node) (container_threads{ container!=""})  * on (node) group_left kube_node_role{ role = "worker" }`, "{{node}}"),
+			t.track("containerThreadsWorker",
+				mg.Raw(`container_threads{container!=""}`).
+					Agg(mg.AggSum, mg.GroupByNode).
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByNode},
+						mg.NodeRoleFilter(mg.RoleWorker)),
+				"{{instance}}"),
 			promQuery("container_threads_sum_by_node_worker", "{{node}}"),
 		)).
 		WithPanel(genericLegendCounterTimeSeries("Control Plane Container Threads", "short",
 			12, 8,
-			promQuery(`sum by (node) (container_threads{ container!=""})  * on (node) group_left kube_node_role{ role = "control-plane" }`, "{{node}}"),
+			t.track("containerThreadsControlPlane",
+				mg.Raw(`container_threads{container!=""}`).
+					Agg(mg.AggSum, mg.GroupByNode).
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByNode},
+						mg.NodeRoleFilter("control-plane")),
+				"{{instance}}"),
 			promQuery("container_threads_sum_by_node_master", "{{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Workers Disk IOPS", "short",
 			12, 8,
-			promQuery(`rate( (  node_disk_reads_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "worker" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - read"),
-			promQuery(`rate( (  node_disk_writes_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "worker" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - write"),
+			t.track("nodeDiskReadsWorker",
+				mg.Raw("node_disk_reads_completed_total").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByInstance},
+						mg.NodeRoleLabelReplace(mg.RoleWorker)).
+					RateSubquery(intervalVar),
+				"{{instance}} - {{ device }} - read"),
+			t.track("nodeDiskWritesWorker",
+				mg.Raw("node_disk_writes_completed_total").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByInstance},
+						mg.NodeRoleLabelReplace(mg.RoleWorker)).
+					RateSubquery(intervalVar),
+				"{{instance}} - {{ device }} - write"),
 		)).
 		WithPanel(genericLegendTimeSeries("Control Plane Disk IOPS", "short",
 			12, 8,
-			promQuery(`rate( (  node_disk_reads_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "control-plane" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - read"),
-			promQuery(`rate( (  node_disk_writes_completed_total *  on (instance) group_left label_replace( kube_node_role{ role = "control-plane" } , "instance" , "$1" , "node" ,"(.*)") )[$interval:])`, "{{instance}} - {{ device }} - write"),
+			t.track("nodeDiskReadsControlPlane",
+				mg.Raw("node_disk_reads_completed_total").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByInstance},
+						mg.NodeRoleLabelReplace("control-plane")).
+					RateSubquery(intervalVar),
+				"{{instance}} - {{ device }} - read"),
+			t.track("nodeDiskWritesControlPlane",
+				mg.Raw("node_disk_writes_completed_total").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByInstance},
+						mg.NodeRoleLabelReplace("control-plane")).
+					RateSubquery(intervalVar),
+				"{{instance}} - {{ device }} - write"),
 		))
 }
 
 // Row: OVN
-func ocpOVNRow() *dashboard.RowBuilder {
+func ocpOVNRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("OVN").
 		Collapsed(true).
 		WithPanel(genericLegendTimeSeries("Top 10 ovnkube-controller CPU Usage", "percent",
 			12, 8,
-			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovnkube-controller"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
+			t.track("ovnkubeControllerCPU",
+				mg.Q(mg.MetricContainerCPU, `pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovnkube-controller"`).
+					IRate(intervalVar).Multiply("100").
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByNode).
+					TopK(10),
+				"{{pod}} - {{node}}"),
 			promQuery(`container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovnkube-controller"}`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 10 ovnkube-controller Memory Usage", "bytes",
 			12, 8,
-			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="ovnkube-controller"}) by (pod,node))`, "{{pod}} - {{node}}"),
+			t.track("ovnkubeControllerMemory",
+				mg.Q(mg.MetricContainerMemoryRSS, `pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="ovnkube-controller"`).
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByNode).
+					TopK(10),
+				"{{pod}} - {{node}}"),
 			promQuery(`container_memory_working_set_bytes_container{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovnkube-controller"}`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 10 ovn-controller CPU Usage", "percent",
 			12, 8,
-			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
+			t.track("ovnControllerCPU",
+				mg.Q(mg.MetricContainerCPU, `pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"`).
+					IRate(intervalVar).Multiply("100").
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByNode).
+					TopK(10),
+				"{{pod}} - {{node}}"),
 			promQuery(`container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"}`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 10 ovn-controller Memory Usage", "bytes",
 			12, 8,
-			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"}) by (pod,node))`, "{{pod}} - {{node}}"),
+			t.track("ovnControllerMemory",
+				mg.Q(mg.MetricContainerMemoryRSS, `pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"`).
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByNode).
+					TopK(10),
+				"{{pod}} - {{node}}"),
 			promQuery(`container_memory_working_set_bytes_container{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="ovn-controller"}`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 10 nbdb CPU Usage", "percent",
 			12, 8,
-			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="nbdb"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
+			t.track("ovnNbdbCPU",
+				mg.Q(mg.MetricContainerCPU, `pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="nbdb"`).
+					IRate(intervalVar).Multiply("100").
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByNode).
+					TopK(10),
+				"{{pod}} - {{node}}"),
 			promQuery(`container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="nbdb"}`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 10 nbdb Memory Usage", "bytes",
 			12, 8,
-			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="nbdb"}) by (pod,node))`, "{{pod}} - {{node}}"),
+			t.track("ovnNbdbMemory",
+				mg.Q(mg.MetricContainerMemoryRSS, `pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="nbdb"`).
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByNode).
+					TopK(10),
+				"{{pod}} - {{node}}"),
 			promQuery(`container_memory_working_set_bytes_container{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="nbdb"}`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 10 northd CPU Usage", "percent",
 			12, 8,
-			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="northd"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
+			t.track("ovnNorthdCPU",
+				mg.Q(mg.MetricContainerCPU, `pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="northd"`).
+					IRate(intervalVar).Multiply("100").
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByNode).
+					TopK(10),
+				"{{pod}} - {{node}}"),
 			promQuery(`container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="northd"}`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 10 northd Memory Usage", "bytes",
 			12, 8,
-			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="northd"}) by (pod,node))`, "{{pod}} - {{node}}"),
+			t.track("ovnNorthdMemory",
+				mg.Q(mg.MetricContainerMemoryRSS, `pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="northd"`).
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByNode).
+					TopK(10),
+				"{{pod}} - {{node}}"),
 			promQuery(`container_memory_working_set_bytes_container{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="northd"}`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 10 sbdb CPU Usage", "percent",
 			12, 8,
-			promQuery(`topk(10, sum( irate(container_cpu_usage_seconds_total{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="sbdb"}[$interval])*100)  by (pod,node) )`, "{{pod}} - {{node}}"),
+			t.track("ovnSbdbCPU",
+				mg.Q(mg.MetricContainerCPU, `pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="sbdb"`).
+					IRate(intervalVar).Multiply("100").
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByNode).
+					TopK(10),
+				"{{pod}} - {{node}}"),
 			promQuery(`container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="sbdb"}`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 10 sbdb Memory Usage", "bytes",
 			12, 8,
-			promQuery(`topk(10, sum(container_memory_rss{pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="sbdb"}) by (pod,node))`, "{{pod}} - {{node}}"),
+			t.track("ovnSbdbMemory",
+				mg.Q(mg.MetricContainerMemoryRSS, `pod=~"ovnkube-node-.*",namespace="openshift-ovn-kubernetes",container="sbdb"`).
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByNode).
+					TopK(10),
+				"{{pod}} - {{node}}"),
 			promQuery(`container_memory_working_set_bytes_container{pod=~"ovnkube-.*",namespace="openshift-ovn-kubernetes",container="sbdb"}`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("ovs-master CPU Usage", "percent",
 			12, 8,
-			promQuery(`irate(container_cpu_usage_seconds_total{id=~"/.*/ovs-vswitchd.service", node=~"$_master_node"}[$interval])*100`, "OVS CPU - {{ node }}"),
+			t.track("ovsMasterVswitchdCPU",
+				mg.Q(mg.MetricContainerCPU, `id=~"/.*/ovs-vswitchd.service", node=~"$_master_node"`).
+					IRate(intervalVar).Multiply("100"),
+				"OVS CPU - {{ node }}"),
 			promQuery(`container_cpu_usage_seconds_total_cgroup_sum_rate_id_node{id=~"/.*/ovs-vswitchd.service", node=~"$_master_node"}`, "OVS CPU - {{ node }}"),
-			promQuery(`irate(container_cpu_usage_seconds_total{id=~"/.*/ovsdb-server.service", node=~"$_master_node"}[$interval])*100`, "OVS DB CPU - {{ node }}"),
+			t.track("ovsMasterOvsdbCPU",
+				mg.Q(mg.MetricContainerCPU, `id=~"/.*/ovsdb-server.service", node=~"$_master_node"`).
+					IRate(intervalVar).Multiply("100"),
+				"OVS DB CPU - {{ node }}"),
 			promQuery(`container_cpu_usage_seconds_total_cgroup_sum_rate_id_node{id=~"/.*/ovsdb-server.service", node=~"$_master_node"}`, "OVS DB CPU - {{ node }}"),
 		)).
 		WithPanel(genericLegendTimeSeries("ovs-master Memory Usage", "bytes",
 			12, 8,
-			promQuery(`container_memory_rss{id=~"/.*/ovs-vswitchd.service", node=~"$_master_node"}`, "OVS Memory - {{ node }}"),
+			t.track("ovsMasterVswitchdMemory", mg.Q(mg.MetricContainerMemoryRSS, `id=~"/.*/ovs-vswitchd.service", node=~"$_master_node"`), "OVS Memory - {{ node }}"),
 			promQuery(`container_memory_rss_cgroup{id=~"/.*/ovs-vswitchd.service", node=~"$_master_node"}`, "OVS Memory - {{ node }}"),
-			promQuery(`container_memory_rss{id=~"/.*/ovsdb-server.service", node=~"$_master_node"}`, "OVS DB Memory - {{ node }}"),
+			t.track("ovsMasterOvsdbMemory", mg.Q(mg.MetricContainerMemoryRSS, `id=~"/.*/ovsdb-server.service", node=~"$_master_node"`), "OVS DB Memory - {{ node }}"),
 			promQuery(`container_memory_rss_cgroup{id=~"/.*/ovsdb-server.service", node=~"$_master_node"}`, "OVS DB Memory - {{ node }}"),
 		)).
 		WithPanel(genericLegendTimeSeries("ovs-worker CPU Usage", "percent",
 			12, 8,
-			promQuery(`irate(container_cpu_usage_seconds_total{id=~"/.*/ovs-vswitchd.service", node=~"$_worker_node"}[$interval])*100`, "OVS CPU - {{ node }}"),
+			t.track("ovsWorkerVswitchdCPU",
+				mg.Q(mg.MetricContainerCPU, `id=~"/.*/ovs-vswitchd.service", node=~"$_worker_node"`).
+					IRate(intervalVar).Multiply("100"),
+				"OVS CPU - {{ node }}"),
 			promQuery(`container_cpu_usage_seconds_total_cgroup_sum_rate_id_node{id=~"/.*/ovs-vswitchd.service", node=~"$_worker_node"}`, "OVS CPU - {{ node }}"),
-			promQuery(`irate(container_cpu_usage_seconds_total{id=~"/.*/ovsdb-server.service", node=~"$_worker_node"}[$interval])*100`, "OVS DB CPU - {{ node }}"),
+			t.track("ovsWorkerOvsdbCPU",
+				mg.Q(mg.MetricContainerCPU, `id=~"/.*/ovsdb-server.service", node=~"$_worker_node"`).
+					IRate(intervalVar).Multiply("100"),
+				"OVS DB CPU - {{ node }}"),
 			promQuery(`container_cpu_usage_seconds_total_cgroup_sum_rate_id_node{id=~"/.*/ovsdb-server.service", node=~"$_worker_node"}`, "OVS DB CPU - {{ node }}"),
 		)).
 		WithPanel(genericLegendTimeSeries("ovs-worker Memory Usage", "bytes",
 			12, 8,
-			promQuery(`container_memory_rss{id=~"/.*/ovs-vswitchd.service", node=~"$_worker_node"}`, "OVS Memory - {{ node }}"),
+			t.track("ovsWorkerVswitchdMemory", mg.Q(mg.MetricContainerMemoryRSS, `id=~"/.*/ovs-vswitchd.service", node=~"$_worker_node"`), "OVS Memory - {{ node }}"),
 			promQuery(`container_memory_rss_cgroup{id=~"/.*/ovs-vswitchd.service", node=~"$_worker_node"}`, "OVS Memory - {{ node }}"),
-			promQuery(`container_memory_rss{id=~"/.*/ovsdb-server.service", node=~"$_worker_node"}`, "OVS DB Memory - {{ node }}"),
+			t.track("ovsWorkerOvsdbMemory", mg.Q(mg.MetricContainerMemoryRSS, `id=~"/.*/ovsdb-server.service", node=~"$_worker_node"`), "OVS DB Memory - {{ node }}"),
 			promQuery(`container_memory_rss_cgroup{id=~"/.*/ovsdb-server.service", node=~"$_worker_node"}`, "OVS DB Memory - {{ node }}"),
 		)).
 		WithPanel(genericLegendTimeSeries("99% Pod Annotation Latency", "s",
 			8, 8,
-			promQuery(`histogram_quantile(0.99, sum by (instance, pod, le) (rate(ovnkube_controller_pod_creation_latency_seconds_bucket[$interval]))) > 0`, "{{ pod }} - {{ instance }}"),
+			t.track("ovnPodAnnotationLatencyP99",
+				mg.Raw("ovnkube_controller_pod_creation_latency_seconds").
+					BucketRate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByInstance, mg.GroupByPod, mg.GroupByLE).
+					HistogramQuantile(mg.P99).
+					Gt("0"),
+				"{{ pod }} - {{ instance }}"),
 		)).
 		WithPanel(genericLegendTimeSeries("99% CNI Request ADD Latency", "s",
 			8, 8,
-			promQuery(`histogram_quantile(0.99, sum(rate(ovnkube_node_cni_request_duration_seconds_bucket{command="ADD"}[$interval])) by (instance,pod,le)) > 0`, "{{ pod }} - {{ instance }}"),
+			t.track("ovnCNIAddLatencyP99",
+				mg.Raw(`ovnkube_node_cni_request_duration_seconds{command="ADD"}`).
+					BucketRate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByInstance, mg.GroupByPod, mg.GroupByLE).
+					HistogramQuantile(mg.P99).
+					Gt("0"),
+				"{{ pod }} - {{ instance }}"),
 		)).
 		WithPanel(genericLegendTimeSeries("99% CNI Request DEL Latency", "s",
 			8, 8,
-			promQuery(`histogram_quantile(0.99, sum(rate(ovnkube_node_cni_request_duration_seconds_bucket{command="DEL"}[$interval])) by (instance,pod,le)) > 0`, "{{ pod }} - {{ instance }}"),
+			t.track("ovnCNIDelLatencyP99",
+				mg.Raw(`ovnkube_node_cni_request_duration_seconds{command="DEL"}`).
+					BucketRate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByInstance, mg.GroupByPod, mg.GroupByLE).
+					HistogramQuantile(mg.P99).
+					Gt("0"),
+				"{{ pod }} - {{ instance }}"),
 		)).
 		WithPanel(genericLegendTimeSeries("ovnkube-control-plane CPU Usage", "percent",
 			12, 8,
-			promQuery(`sum( irate(container_cpu_usage_seconds_total{pod=~"(ovnkube-master|ovnkube-control-plane).+",namespace="openshift-ovn-kubernetes",container!~"POD|"}[$interval])*100 ) by (pod, node)`, "{{pod}} - {{node}}"),
+			t.track("ovnkubeControlPlaneCPU",
+				mg.Q(mg.MetricContainerCPU, `pod=~"(ovnkube-master|ovnkube-control-plane).+",namespace="openshift-ovn-kubernetes",container!~"POD|"`).
+					IRate(intervalVar).Multiply("100").
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByNode),
+				"{{pod}} - {{node}}"),
 			promQuery(`sum(container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{pod=~"(ovnkube-master|ovnkube-control-plane).+",namespace="openshift-ovn-kubernetes"}) by (pod, node)`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("ovnkube-control-plane Memory Usage", "bytes",
 			12, 8,
-			promQuery(`sum(container_memory_rss{pod=~"(ovnkube-master|ovnkube-control-plane).+",namespace="openshift-ovn-kubernetes",container!~"POD|"}) by (pod,node)`, "{{pod}} - {{node}}"),
+			t.track("ovnkubeControlPlaneMemory",
+				mg.Q(mg.MetricContainerMemoryRSS, `pod=~"(ovnkube-master|ovnkube-control-plane).+",namespace="openshift-ovn-kubernetes",container!~"POD|"`),
+				"{{pod}} - {{node}}"),
 			promQuery(`sum(container_memory_working_set_bytes_container{pod=~"(ovnkube-master|ovnkube-control-plane).+",namespace="openshift-ovn-kubernetes"}) by (pod,node)`, "{{pod}} - {{node}}"),
 		))
 }
 
 // Row: Monitoring stack
-func ocpMonitoringStackRow() *dashboard.RowBuilder {
+func ocpMonitoringStackRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Monitoring stack").
 		Collapsed(true).
 		WithPanel(genericLegendTimeSeries("Prometheus Replica CPU", "percent",
 			12, 8,
-			promQuery(`sum(irate(container_cpu_usage_seconds_total{pod=~"prometheus-k8s-[01]",namespace!="",name!="",container="prometheus"}[$interval])) by (pod,container,node) * 100`, "{{pod}} - {{node}}"),
+			t.track("prometheusCPU",
+				mg.Q(mg.MetricContainerCPU, `pod=~"prometheus-k8s-[01]",namespace!="",name!="",container="prometheus"`).
+					IRate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByContainer, mg.GroupByNode).
+					Multiply("100"),
+				"{{pod}} - {{node}}"),
 			promQuery(`container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{pod=~"prometheus-k8s-[01]",namespace!="",name!="",container="prometheus"}`, "{{pod}} - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Prometheus Replica RSS", "bytes",
 			12, 8,
-			promQuery(`sum(container_memory_rss{pod=~"prometheus-k8s-[01]",namespace!="",name!="",container="prometheus"}) by (pod)`, "{{pod}}"),
+			t.track("prometheusMemory",
+				mg.Q(mg.MetricContainerMemoryRSS, `pod=~"prometheus-k8s-[01]",namespace!="",name!="",container="prometheus"`).
+					Agg(mg.AggSum, mg.GroupByPod),
+				"{{pod}}"),
 			promQuery(`container_memory_working_set_bytes_container{pod=~"prometheus-k8s-[01]",namespace!="",name!="",container="prometheus"}`, "{{pod}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("metrics-server/prom-adapter CPU", "percent",
 			12, 8,
-			promQuery(`sum(irate(container_cpu_usage_seconds_total{pod=~"metrics-server-.*",namespace!="",name!=""}[$interval])) by (pod,container) * 100`, "{{pod}}"),
+			t.track("metricsServerCPU",
+				mg.Q(mg.MetricContainerCPU, `pod=~"metrics-server-.*",namespace!="",name!=""`).
+					IRate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByContainer).
+					Multiply("100"),
+				"{{pod}}"),
 			promQuery(`container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{pod=~"metrics-server-.*",namespace!="",name!=""}`, "{{pod}}"),
-			promQuery(`sum(irate(container_cpu_usage_seconds_total{pod=~"prometheus-adapter-.*",namespace="openshift-monitoring",name!=""}[$interval])) by (pod,container) * 100`, "{{pod}}"),
+			t.track("promAdapterCPU",
+				mg.Q(mg.MetricContainerCPU, `pod=~"prometheus-adapter-.*",namespace="openshift-monitoring",name!=""`).
+					IRate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByContainer).
+					Multiply("100"),
+				"{{pod}}"),
 			promQuery(`container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{pod=~"prometheus-adapter-.*",namespace="openshift-monitoring",name!=""}`, "{{pod}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("metrics-server/prom-adapter RSS", "bytes",
 			12, 8,
-			promQuery(`sum(container_memory_rss{pod=~"metrics-server-.*",namespace!="",name!=""}) by (pod)`, "{{pod}}"),
+			t.track("metricsServerMemory",
+				mg.Q(mg.MetricContainerMemoryRSS, `pod=~"metrics-server-.*",namespace!="",name!=""`).
+					Agg(mg.AggSum, mg.GroupByPod),
+				"{{pod}}"),
 			promQuery(`container_memory_working_set_bytes_container{pod=~"metrics-server-.*",namespace!="",name!=""}`, "{{pod}}"),
-			promQuery(`sum(container_memory_rss{pod=~"prometheus-adapter-.*",namespace="openshift-monitoring",name!=""}) by (pod)`, "{{pod}}"),
+			t.track("promAdapterMemory",
+				mg.Q(mg.MetricContainerMemoryRSS, `pod=~"prometheus-adapter-.*",namespace="openshift-monitoring",name!=""`).
+					Agg(mg.AggSum, mg.GroupByPod),
+				"{{pod}}"),
 			promQuery(`container_memory_working_set_bytes_container{pod=~"prometheus-adapter-.*",namespace="openshift-monitoring",name!=""}`, "{{pod}}"),
 		))
 }
 
 // Row: Stackrox
-func ocpStackroxRow() *dashboard.RowBuilder {
+func ocpStackroxRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Stackrox").
 		Collapsed(true).
 		WithPanel(genericLegendTimeSeries("Top 25 stackrox container RSS bytes", "bytes",
 			12, 8,
-			promQuery(`topk(25, container_memory_rss{container!="POD",name!="",namespace!="",namespace=~"stackrox"})`, "{{ pod }}: {{ container }}"),
+			t.track("stackroxContainerMemoryRSS",
+				mg.Q(mg.MetricContainerMemoryRSS, `container!="POD",name!="",namespace!="",namespace=~"stackrox"`).
+					TopK(25),
+				"{{ pod }}: {{ container }}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 25 stackrox container CPU percent", "percent",
 			12, 8,
-			promQuery(`topk(25, sum(irate(container_cpu_usage_seconds_total{container!="POD",name!="",namespace!="",namespace=~"stackrox"}[$interval])) by (pod,container,namespace,name,service) * 100)`, "{{ pod }}: {{ container }}"),
+			t.track("stackroxContainerCPU",
+				mg.Q(mg.MetricContainerCPU, `container!="POD",name!="",namespace!="",namespace=~"stackrox"`).
+					IRate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByContainer, mg.GroupByNamespace, mg.GroupByName, "service").
+					Multiply("100").
+					TopK(25),
+				"{{ pod }}: {{ container }}"),
 		))
 }
 
 // Row: Cluster Kubelet
-func ocpClusterKubeletRow() *dashboard.RowBuilder {
+func ocpClusterKubeletRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Cluster Kubelet").
 		Collapsed(true).
 		WithPanel(genericLegendTimeSeries("Top 10 Kubelet CPU usage", "percent",
 			12, 8,
-			promQuery(`topk(10,irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[$interval])*100 *  on (node) group_left kube_node_role{ role = "worker" })`, "kubelet - {{node}}"),
+			t.track("kubeletCPU",
+				mg.Q(mg.MetricProcessCPU, `service="kubelet",job="kubelet"`).
+					IRate(intervalVar).Multiply("100").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByNode},
+						mg.NodeRoleFilter(mg.RoleWorker)).
+					TopK(10),
+				"kubelet - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 10 crio CPU usage", "percent",
 			12, 8,
-			promQuery(`topk(10,irate(process_cpu_seconds_total{service="kubelet",job="crio"}[$interval])*100 *  on (node) group_left kube_node_role{ role = "worker" })`, "crio - {{node}}"),
+			t.track("crioCPU",
+				mg.Q(mg.MetricProcessCPU, `service="kubelet",job="crio"`).
+					IRate(intervalVar).Multiply("100").
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByNode},
+						mg.NodeRoleFilter(mg.RoleWorker)).
+					TopK(10),
+				"crio - {{node}}"),
 		)).
 		WithPanel(genericLegendCounterTimeSeries("Top 10 Kubelet memory usage", "bytes",
 			12, 8,
-			promQuery(`topk(10,process_resident_memory_bytes{service="kubelet",job="kubelet"} *  on (node) group_left kube_node_role{ role = "worker" })`, "kubelet - {{node}}"),
+			t.track("kubeletMemory",
+				mg.Q(mg.MetricProcessMemory, `service="kubelet",job="kubelet"`).
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByNode},
+						mg.NodeRoleFilter(mg.RoleWorker)).
+					TopK(10),
+				"kubelet - {{node}}"),
 		)).
 		WithPanel(genericLegendCounterTimeSeries("Top 10 crio memory usage", "bytes",
 			12, 8,
-			promQuery(`topk(10,process_resident_memory_bytes{service="kubelet",job="crio"} *  on (node) group_left kube_node_role{ role = "worker" })`, "crio - {{node}}"),
+			t.track("crioMemory",
+				mg.Q(mg.MetricProcessMemory, `service="kubelet",job="crio"`).
+					MultiplyOnGroupLeft([]mg.GroupBy{mg.GroupByNode},
+						mg.NodeRoleFilter(mg.RoleWorker)).
+					TopK(10),
+				"crio - {{node}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("inodes usage in /run", "percent",
 			12, 8,
-			promQuery(`(1 - node_filesystem_files_free{fstype!="",mountpoint="/run"} / node_filesystem_files{fstype!="",mountpoint="/run"}) * 100`, "{{instance}}"),
+			t.trackRaw("nodeInodesUsageRun", `(1 - node_filesystem_files_free{fstype!="",mountpoint="/run"} / node_filesystem_files{fstype!="",mountpoint="/run"}) * 100`, "{{instance}}"),
 		)).
 		WithPanel(genericLegendCounterSumRightHandTimeSeries("inodes count in /run", "none",
 			12, 8,
-			promQuery(`node_filesystem_files{fstype!="",mountpoint="/run"} - node_filesystem_files_free{fstype!="",mountpoint="/run"}`, "{{instance}}"),
-			promQuery(`sum(node_filesystem_files{fstype!="",mountpoint="/run"} - node_filesystem_files_free{fstype!="",mountpoint="/run"})`, "sum"),
-		))
+			t.track("nodeInodesCountRun",
+				mg.Q(mg.MetricNodeFsFiles, `fstype!="",mountpoint="/run"`).
+					Sub(mg.Q(mg.MetricNodeFsFilesFree, `fstype!="",mountpoint="/run"`)),
+				"{{instance}}"),
+			promQuery(
+				mg.Q(mg.MetricNodeFsFiles, `fstype!="",mountpoint="/run"`).
+					Sub(mg.Q(mg.MetricNodeFsFilesFree, `fstype!="",mountpoint="/run"`)).
+					Agg(mg.AggSum).String(),
+				"sum"),
+			))
 }
 
 // Row: Cluster Details
-func ocpClusterDetailsRow() *dashboard.RowBuilder {
+func ocpClusterDetailsRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Cluster Details").
 		Collapsed(true).
 		WithPanel(genericStat("Current Node Count",
 			8, 3,
-			promQuery(`sum(kube_node_info{})`, "Number of nodes"),
-			promQuery(`sum(kube_node_status_condition{status="true"}) by (condition) > 0`, "Node: {{ condition }}"),
+			t.track("kubeNodeInfo", mg.Raw("kube_node_info{}").Agg(mg.AggSum), "Number of nodes"),
+			t.track("kubeNodeStatusCondition",
+				mg.Q(mg.MetricKubeNodeStatusCondition, `status="true"`).
+					Agg(mg.AggSum, mg.GroupByCondition).
+					Gt("0"),
+				"Node: {{ condition }}"),
 		)).
 		WithPanel(genericStat("Current Namespace Count",
 			8, 3,
-			promQuery(`sum(kube_namespace_status_phase) by (phase)`, "{{ phase }}"),
+			t.track("kubeNamespacePhase",
+				mg.Q(mg.MetricKubeNamespacePhase, "").
+					Agg(mg.AggSum, mg.GroupByPhase),
+				"{{ phase }}"),
 			promQuery(`kube_namespace_status_phase_sum_by_phase`, "{{ phase }}"),
 		)).
 		WithPanel(genericStat("Current Pod Count",
 			8, 3,
-			promQuery(`sum(kube_pod_status_phase{}) by (phase) > 0`, "{{ phase}} Pods"),
+			t.track("kubePodStatusPhase",
+				mg.Q(mg.MetricKubePodStatusPhase, "").
+					Agg(mg.AggSum, mg.GroupByPhase).
+					Gt("0"),
+				"{{ phase}} Pods"),
 			promQuery(`sum(kube_pod_info_by_node)`, "{{ phase}} Pods"),
 		)).
 		WithPanel(genericTimeSeries("Number of nodes", "none",
 			8, 8,
-			promQuery(`sum(kube_node_info{})`, "Number of nodes"),
-			promQuery(`sum(kube_node_status_condition{status="true"}) by (condition) > 0`, "Node: {{ condition }}"),
+			promQuery(mg.Raw("kube_node_info{}").Agg(mg.AggSum).String(), "Number of nodes"),
+			promQuery(
+				mg.Q(mg.MetricKubeNodeStatusCondition, `status="true"`).
+					Agg(mg.AggSum, mg.GroupByCondition).
+					Gt("0").String(),
+				"Node: {{ condition }}"),
 		)).
 		WithPanel(genericTimeSeries("Namespace count", "none",
 			8, 8,
-			promQuery(`sum(kube_namespace_status_phase) by (phase) > 0`, "{{ phase }} namespaces"),
+			promQuery(
+				mg.Q(mg.MetricKubeNamespacePhase, "").
+					Agg(mg.AggSum, mg.GroupByPhase).
+					Gt("0").String(),
+				"{{ phase }} namespaces"),
 			promQuery(`kube_namespace_status_phase_sum_by_phase > 0`, "{{ phase }} namespaces"),
 		)).
 		WithPanel(genericTimeSeries("Pod count", "none",
 			8, 8,
-			promQuery(`sum(kube_pod_status_phase{}) by (phase)`, "{{phase}} pods"),
+			promQuery(
+				mg.Q(mg.MetricKubePodStatusPhase, "").
+					Agg(mg.AggSum, mg.GroupByPhase).String(),
+				"{{phase}} pods"),
 			promQuery(`kube_pod_status_phase_sum_by_failed`, "Failed pods"),
 			promQuery(`kube_pod_status_phase_sum_by_pending`, "Pending pods"),
 			promQuery(`kube_pod_status_phase_sum_by_running`, "Running pods"),
@@ -400,284 +734,251 @@ func ocpClusterDetailsRow() *dashboard.RowBuilder {
 		)).
 		WithPanel(genericTimeSeries("Secret & configmap count", "none",
 			8, 8,
-			promQuery(`count(kube_secret_info{})`, "secrets"),
+			t.track("kubeSecretInfo", mg.Q(mg.MetricKubeSecretInfo, "").Agg(mg.AggCount), "secrets"),
 			promQuery(`kube_secret_info_count`, "secrets"),
-			promQuery(`count(kube_configmap_info{})`, "Configmaps"),
+			t.track("kubeConfigmapInfo", mg.Q(mg.MetricKubeConfigmapInfo, "").Agg(mg.AggCount), "Configmaps"),
 			promQuery(`kube_configmap_info_count`, "Configmaps"),
 		)).
 		WithPanel(genericTimeSeries("Deployment count", "none",
 			8, 8,
-			promQuery(`count(kube_deployment_spec_replicas{})`, "Deployments"),
+			t.track("kubeDeploymentReplicas", mg.Raw("kube_deployment_spec_replicas{}").Agg(mg.AggCount), "Deployments"),
 			promQuery(`kube_deployment_spec_paused_count`, "Deployments"),
 		)).
 		WithPanel(genericTimeSeries("Services count", "none",
 			8, 8,
-			promQuery(`count(kube_service_info{})`, "Services"),
+			t.track("kubeServiceInfo", mg.Q(mg.MetricKubeServiceInfo, "").Agg(mg.AggCount), "Services"),
 			promQuery(`kube_service_info_count`, "Services"),
 		)).
 		WithPanel(genericTimeSeries("Routes count", "none",
 			8, 8,
-			promQuery(`count(openshift_route_info{})`, "Routes"),
+			t.track("openshiftRouteInfo", mg.Raw("openshift_route_info{}").Agg(mg.AggCount), "Routes"),
 			promQuery(`openshift_route_info_count`, "Routes"),
 		)).
 		WithPanel(genericTimeSeries("Alerts", "none",
 			8, 8,
-			promQuery(`topk(10,sum(ALERTS{severity!="none"}) by (alertname, severity))`, "{{severity}}: {{alertname}}"),
+			t.trackRaw("alerts", `topk(10,sum(ALERTS{severity!="none"}) by (alertname, severity))`, "{{severity}}: {{alertname}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Pod Distribution", "none",
 			8, 8,
-			promQuery(`count(kube_pod_info{}) by (node)`, "{{ node }}"),
+			t.track("kubePodDistribution",
+				mg.Q(mg.MetricKubePodInfo, "").
+					Agg(mg.AggCount, mg.GroupByNode),
+				"{{ node }}"),
 			promQuery(`kube_pod_info_by_node`, "{{ node }}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 10 container CPU", "percent",
 			12, 8,
-			promQuery(`topk(10,irate(container_cpu_usage_seconds_total{namespace!="",container!="POD",name!=""}[$interval])*100)`, "{{ namespace }} - {{ pod }} - {{ node }}"),
+			t.track("containerCPUTop10",
+				mg.Q(mg.MetricContainerCPU, `namespace!="",container!="POD",name!=""`).
+					IRate(intervalVar).Multiply("100").
+					TopK(10),
+				"{{ namespace }} - {{ name }} - {{ node }}"),
 			promQuery(`topk(10,container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{namespace!="",container!="POD",name!=""})`, "{{ namespace }} - {{ pod }} - {{ node }}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Top 10 container RSS", "bytes",
 			12, 8,
-			promQuery(`topk(10, container_memory_rss{namespace!="",container!="POD",name!=""})`, "{{ namespace }} - {{ pod }} - {{ node }}"),
+			t.track("containerMemoryRSSTop10",
+				mg.Q(mg.MetricContainerMemoryRSS, `namespace!="",container!="POD",name!=""`).
+					TopK(10),
+				"{{ namespace }} - {{ name }} - {{ node }}"),
 			promQuery(`topk(10, container_memory_working_set_bytes_container{namespace!="",container!="POD",name!=""})`, "{{ namespace }} - {{ pod }} - {{ node }}"),
 		)).
 		WithPanel(genericLegendTimeSeries("container RSS system.slice", "bytes",
 			12, 8,
-			promQuery(`sum by (node)(container_memory_rss{id="/system.slice"})`, "system.slice - {{ node }}"),
+			t.track("containerMemoryRSSSystemSlice",
+				mg.Q(mg.MetricContainerMemoryRSS, `id="/system.slice"`).
+					Agg(mg.AggSum, mg.GroupByNode),
+				"system.slice - {{ node }}"),
 			promQuery(`container_memory_working_set_bytes_cgroup{id="/system.slice"}`, "system.slice - {{ node }}"),
 		)).
 		WithPanel(genericTimeSeries("Goroutines count", "none",
 			12, 8,
-			promQuery(`topk(10, sum(go_goroutines{}) by (job,instance))`, "{{ job }} - {{ instance }}"),
+			t.trackRaw("goGoroutines", `topk(10, sum(go_goroutines{}) by (job,instance))`, "{{ job }} - {{ instance }}"),
 		))
 }
 
 // Row: Cluster Operators Details
-func ocpClusterOperatorsDetailsRow() *dashboard.RowBuilder {
+func ocpClusterOperatorsDetailsRow(t panelTracker) *dashboard.RowBuilder {
 	return dashboard.NewRowBuilder("Cluster Operators Details").
 		Collapsed(true).
 		WithPanel(genericStat("Cluster operators overview",
 			24, 3,
-			promQuery(`sum by (condition)(cluster_operator_conditions{condition!=""})`, "{{ condition }}"),
+			t.track("clusterOperatorConditions",
+				mg.Q(mg.MetricClusterOperatorConditions, `condition!=""`).
+					Agg(mg.AggSum, mg.GroupByCondition),
+				"{{ condition }}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Cluster operators information", "none",
 			8, 8,
-			promQuery(`cluster_operator_conditions{name!="",reason!=""}`, "{{name}} - {{reason}}"),
+			t.track("clusterOperatorInfo", mg.Q(mg.MetricClusterOperatorConditions, `name!="",reason!=""`), "{{name}} - {{reason}}"),
 		)).
 		WithPanel(genericLegendTimeSeries("Cluster operators degraded", "none",
 			8, 8,
-			promQuery(`cluster_operator_conditions{condition="Degraded",name!="",reason!=""}`, "{{name}} - {{reason}}"),
+			t.track("clusterOperatorDegraded", mg.Q(mg.MetricClusterOperatorConditions, `condition="Degraded",name!="",reason!=""`), "{{name}} - {{reason}}"),
 		))
 }
 
-// Row: Master (repeats on _master_node)
-func ocpMasterRow() *dashboard.RowBuilder {
-	return dashboard.NewRowBuilder("Master: $_master_node").
-		Collapsed(true).
-		Repeat("_master_node").
-		WithPanel(genericLegendTimeSeries("CPU Basic: $_master_node", "percent",
-			12, 8,
-			promQuery(`sum by (instance, mode)(irate(node_cpu_seconds_total{instance=~"$_master_node",job=~".*"}[$interval])) * 100`, "Busy {{mode}}"),
-			promQuery(`node_cpu_seconds_sum_rate_2m_30s_instance_mode_node_panel{instance=~"$_master_node"}`, "Busy {{mode}}"),
-		)).
-		WithPanel(genericLegendCounterTimeSeries("System Memory: $_master_node", "bytes",
-			12, 8,
-			promQuery(`node_memory_Active_bytes{instance=~"$_master_node"}`, "Active"),
-			promQuery(`node_memory_MemTotal_bytes{instance=~"$_master_node"}`, "Total"),
-			promQuery(`node_memory_Cached_bytes{instance=~"$_master_node"} + node_memory_Buffers_bytes{instance=~"$_master_node"}`, "Cached + Buffers"),
-			promQuery(`node_memory_MemAvailable_bytes{instance=~"$_master_node"}`, "Available"),
-			promQuery(`(node_memory_MemTotal_bytes{instance=~"$_master_node"} - (node_memory_MemFree_bytes{instance=~"$_master_node"} + node_memory_Buffers_bytes{instance=~"$_master_node"} +  node_memory_Cached_bytes{instance=~"$_master_node"}))`, "Used"),
-		)).
-		WithPanel(genericLegendTimeSeries("Disk throughput: $_master_node", "Bps",
-			12, 8,
-			promQuery(`rate(node_disk_read_bytes_total{device=~"$block_device",instance=~"$_master_node"}[$interval])`, "{{ device }} - read"),
-			promQuery(`rate(node_disk_written_bytes_total{device=~"$block_device",instance=~"$_master_node"}[$interval])`, "{{ device }} - write"),
-		)).
-		WithPanel(genericLegendTimeSeries("Disk IOPS: $_master_node", "iops",
-			12, 8,
-			promQuery(`rate(node_disk_reads_completed_total{device=~"$block_device",instance=~"$_master_node"}[$interval])`, "{{ device }} - read"),
-			promQuery(`rate(node_disk_writes_completed_total{device=~"$block_device",instance=~"$_master_node"}[$interval])`, "{{ device }} - write"),
-		)).
-		WithPanel(genericLegendTimeSeries("Network Utilization: $_master_node", "bps",
-			12, 8,
-			promQuery(`rate(node_network_receive_bytes_total{instance=~"$_master_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - RX"),
-			promQuery(`rate(node_network_transmit_bytes_total{instance=~"$_master_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - TX"),
-		)).
-		WithPanel(genericLegendTimeSeries("Network Packets: $_master_node", "pps",
-			12, 8,
-			promQuery(`rate(node_network_receive_packets_total{instance=~"$_master_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - RX"),
-			promQuery(`rate(node_network_transmit_packets_total{instance=~"$_master_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - TX"),
-		)).
-		WithPanel(genericLegendTimeSeries("Network packets drop: $_master_node", "pps",
-			12, 8,
-			promQuery(`topk(10, rate(node_network_receive_drop_total{instance=~"$_master_node"}[$interval]))`, "rx-drop-{{ device }}"),
-			promQuery(`topk(10,rate(node_network_transmit_drop_total{instance=~"$_master_node"}[$interval]))`, "tx-drop-{{ device }}"),
-		)).
-		WithPanel(genericLegendCounterTimeSeries("Conntrack stats: $_master_node", "",
-			12, 8,
-			promQuery(`node_nf_conntrack_entries{instance=~"$_master_node"}`, "conntrack_entries"),
-			promQuery(`node_nf_conntrack_entries_limit{instance=~"$_master_node"}`, "conntrack_limit"),
-		)).
-		WithPanel(genericLegendTimeSeries("Top 10 container CPU: $_master_node", "percent",
-			12, 8,
-			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container!="POD",name!="",node=~"$_master_node",namespace!="",namespace=~"$namespace"}[$interval])) by (pod,container,namespace,name,service) * 100)`, "{{ pod }}: {{ container }}"),
-			promQuery(`topk(10, container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{node=~"$_master_node",namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
-		)).
-		WithPanel(genericLegendCounterTimeSeries("Top 10 container RSS: $_master_node", "bytes",
-			12, 8,
-			promQuery(`topk(10, container_memory_rss{container!="POD",name!="",node=~"$_master_node",namespace!="",namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
-			promQuery(`topk(10, container_memory_working_set_bytes_container{node=~"$_master_node",namespace=~"$namespace"})`, "{{pod}} - {{node}}"),
-		)).
-		WithPanel(genericLegendTimeSeries("cgroup CPU: $_master_node", "percent",
-			12, 8,
-			promQuery(`sum by (id) ( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice", node=~"$_master_node"}[$interval])) * 100`, "{{ id }}"),
-			promQuery(`container_cpu_usage_seconds_total_cgroup_sum_rate_id_node{node=~"$_master_node"}`, "{{ id }}"),
-		)).
-		WithPanel(genericLegendCounterTimeSeries("cgroup RSS: $_master_node", "bytes",
-			12, 8,
-			promQuery(`sum by (id) ( container_memory_rss{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/system.slice/.*.service|/system.slice/systemd-udevd.service|/kubepods.slice", node=~"$_master_node"})`, "{{ id }}"),
-			promQuery(`container_memory_working_set_bytes_cgroup{node=~"$_master_node"}`, "{{ id }}"),
-		)).
-		WithPanel(genericLegendTimeSeries("Pod fs rw rate: $_master_node", "Bps",
-			12, 8,
-			promQuery(`sum(rate(container_fs_writes_bytes_total{device!~".+dm.+", node=~"$_master_node", pod!=""}[$interval])) by (device, pod)`, "{{ pod }}: {{ device }} - write"),
-			promQuery(`container_fs_writes_bytes_total_container_sum_rate_pod_node_device{node=~"$_master_node"}`, "{{ pod }}: {{ device }} - write"),
-			promQuery(`sum(rate(container_fs_reads_bytes_total{device!~".+dm.+", node=~"$_master_node", pod!=""}[$interval])) by (device, pod)`, "{{ pod }}: {{ device }} - read"),
-			promQuery(`container_fs_reads_bytes_total_container_sum_rate_pod_node_device{node=~"$_master_node"}`, "{{ pod }}: {{ device }} - read"),
-		)).
-		WithPanel(genericLegendTimeSeries("cgroup fs rw rate: $_master_node", "Bps",
-			12, 8,
-			promQuery(`sum(rate(container_fs_writes_bytes_total{device!~".+dm.+", node=~"$_master_node", id =~"/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) by (device, id)`, "{{ id }}: {{ device }} - write"),
-			promQuery(`container_fs_writes_bytes_total_cgroup_sum_rate_id_node_device{node=~"$_master_node"}`, "{{ id }}: {{ device }} - write"),
-			promQuery(`sum(rate(container_fs_reads_bytes_total{device!~".+dm.+", node=~"$_master_node", id =~"/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice"}[$interval])) by (device, id)`, "{{ id }}: {{ device }} - read"),
-			promQuery(`container_fs_reads_bytes_total_cgroup_sum_rate_id_node_device{node=~"$_master_node"}`, "{{ id }}: {{ device }} - read"),
-		))
-}
+func ocpNodeRow(t panelTracker, nodeVar string, role mg.NodeRole) *dashboard.RowBuilder {
+	instanceFilter := `instance=~"$` + nodeVar + `"`
+	nodeFilter := `node=~"$` + nodeVar + `"`
+	roleStr := string(role)
 
-// Row: Worker (repeats on _worker_node)
-func ocpWorkerRow() *dashboard.RowBuilder {
-	return dashboard.NewRowBuilder("Worker: $_worker_node").
+	row := dashboard.NewRowBuilder(roleStr + ": $" + nodeVar).
 		Collapsed(true).
-		Repeat("_worker_node").
-		WithPanel(genericLegendTimeSeries("CPU Basic: $_worker_node", "percent",
+		GridPos(dashboard.GridPos{X: 0, Y: 0, W: 24, H: 8}).
+		Repeat(nodeVar).
+		WithPanel(genericLegendTimeSeries("CPU Basic: $"+nodeVar, "percent",
 			12, 8,
-			promQuery(`sum by (instance, mode)(irate(node_cpu_seconds_total{instance=~"$_worker_node",job=~".*"}[$interval])) * 100`, "Busy {{mode}}"),
-			promQuery(`node_cpu_seconds_sum_rate_2m_30s_instance_mode_node_panel{instance=~"$_worker_node",job=~".*"}`, "Busy {{mode}}"),
+			t.track("nodeCPU",
+				mg.Q(mg.MetricNodeCPU, instanceFilter+`,job=~".*"`).
+					IRate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByInstance, mg.GroupByMode).
+					Multiply("100"),
+				"Busy {{mode}}"),
+			promQuery(`node_cpu_seconds_sum_rate_2m_30s_instance_mode_node_panel{`+instanceFilter+`}`, "Busy {{mode}}"),
 		)).
-		WithPanel(genericLegendCounterTimeSeries("System Memory: $_worker_node", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("System Memory: $"+nodeVar, "bytes",
 			12, 8,
-			promQuery(`node_memory_Active_bytes{instance=~"$_worker_node"}`, "Active"),
-			promQuery(`node_memory_MemTotal_bytes{instance=~"$_worker_node"}`, "Total"),
-			promQuery(`node_memory_Cached_bytes{instance=~"$_worker_node"} + node_memory_Buffers_bytes{instance=~"$_worker_node"}`, "Cached + Buffers"),
-			promQuery(`node_memory_MemAvailable_bytes{instance=~"$_worker_node"}`, "Available"),
-			promQuery(`(node_memory_MemTotal_bytes{instance=~"$_worker_node"} - (node_memory_MemFree_bytes{instance=~"$_worker_node"} + node_memory_Buffers_bytes{instance=~"$_worker_node"} +  node_memory_Cached_bytes{instance=~"$_worker_node"}))`, "Used"),
+			t.track("nodeMemoryActive", mg.Q(mg.MetricNodeMemoryActive, instanceFilter), "Active"),
+			t.track("nodeMemoryTotal", mg.Q(mg.MetricNodeMemoryTotal, instanceFilter), "Total"),
+			t.trackRaw("nodeMemoryCachedBuffers",
+				`node_memory_Cached_bytes{`+instanceFilter+`} + node_memory_Buffers_bytes{`+instanceFilter+`}`,
+				"Cached + Buffers"),
+			t.track("nodeMemoryAvailable", mg.Q(mg.MetricNodeMemoryAvailable, instanceFilter), "Available"),
+			t.track("nodeMemoryUsed",
+				mg.Q(mg.MetricNodeMemoryTotal, instanceFilter).
+					Sub(mg.Q(mg.MetricNodeMemoryFree, instanceFilter).Paren()),
+				"Used"),
 		)).
-		WithPanel(genericLegendTimeSeries("Disk throughput: $_worker_node", "Bps",
+		WithPanel(genericLegendTimeSeries("Disk throughput: $"+nodeVar, "Bps",
 			12, 8,
-			promQuery(`rate(node_disk_read_bytes_total{device=~"$block_device",instance=~"$_worker_node"}[$interval])`, "{{ device }} - read"),
-			promQuery(`rate(node_disk_written_bytes_total{device=~"$block_device",instance=~"$_worker_node"}[$interval])`, "{{ device }} - write"),
+			t.track("nodeDiskRead",
+				mg.Q(mg.MetricNodeDiskRead, `device=~"$block_device",`+instanceFilter).
+					Rate(intervalVar),
+				"{{ device }} - read"),
+			t.track("nodeDiskWritten",
+				mg.Q(mg.MetricNodeDiskWritten, `device=~"$block_device",`+instanceFilter).
+					Rate(intervalVar),
+				"{{ device }} - write"),
 		)).
-		WithPanel(genericLegendTimeSeries("Disk IOPS: $_worker_node", "iops",
+		WithPanel(genericLegendTimeSeries("Disk IOPS: $"+nodeVar, "iops",
 			12, 8,
-			promQuery(`rate(node_disk_reads_completed_total{device=~"$block_device",instance=~"$_worker_node"}[$interval])`, "{{ device }} - read"),
-			promQuery(`rate(node_disk_writes_completed_total{device=~"$block_device",instance=~"$_worker_node"}[$interval])`, "{{ device }} - write"),
+			t.track("nodeDiskReadsCompleted",
+				mg.Raw("node_disk_reads_completed_total{device=~\"$block_device\","+instanceFilter+"}").
+					Rate(intervalVar),
+				"{{ device }} - read"),
+			t.track("nodeDiskWritesCompleted",
+				mg.Raw("node_disk_writes_completed_total{device=~\"$block_device\","+instanceFilter+"}").
+					Rate(intervalVar),
+				"{{ device }} - write"),
 		)).
-		WithPanel(genericLegendTimeSeries("Network Utilization: $_worker_node", "bps",
+		WithPanel(genericLegendTimeSeries("Network Utilization: $"+nodeVar, "bps",
 			12, 8,
-			promQuery(`rate(node_network_receive_bytes_total{instance=~"$_worker_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - RX"),
-			promQuery(`rate(node_network_transmit_bytes_total{instance=~"$_worker_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - TX"),
+			t.track("nodeNetworkRx",
+				mg.Q(mg.MetricNodeNetworkRx, instanceFilter+`,device=~"$net_device"`).
+					Rate(intervalVar).Multiply("8"),
+				"{{instance}} - {{device}} - RX"),
+			t.track("nodeNetworkTx",
+				mg.Q(mg.MetricNodeNetworkTx, instanceFilter+`,device=~"$net_device"`).
+					Rate(intervalVar).Multiply("8"),
+				"{{instance}} - {{device}} - TX"),
 		)).
-		WithPanel(genericLegendTimeSeries("Network Packets: $_worker_node", "pps",
+		WithPanel(genericLegendTimeSeries("Network Packets: $"+nodeVar, "pps",
 			12, 8,
-			promQuery(`rate(node_network_receive_packets_total{instance=~"$_worker_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - RX"),
-			promQuery(`rate(node_network_transmit_packets_total{instance=~"$_worker_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - TX"),
+			t.track("nodeNetworkRxPackets",
+				mg.Raw("node_network_receive_packets_total{"+instanceFilter+`,device=~"$net_device"}`).
+					Rate(intervalVar),
+				"{{instance}} - {{device}} - RX"),
+			t.track("nodeNetworkTxPackets",
+				mg.Raw("node_network_transmit_packets_total{"+instanceFilter+`,device=~"$net_device"}`).
+					Rate(intervalVar),
+				"{{instance}} - {{device}} - TX"),
 		)).
-		WithPanel(genericLegendTimeSeries("Network packets drop: $_worker_node", "pps",
+		WithPanel(genericLegendTimeSeries("Network packets drop: $"+nodeVar, "pps",
 			12, 8,
-			promQuery(`topk(10, rate(node_network_receive_drop_total{instance=~"$_worker_node"}[$interval]))`, "rx-drop-{{ device }}"),
-			promQuery(`topk(10,rate(node_network_transmit_drop_total{instance=~"$_worker_node"}[$interval]))`, "tx-drop-{{ device }}"),
+			t.track("nodeNetworkRxDrop",
+				mg.Q(mg.MetricNodeNetworkRxDrop, instanceFilter).
+					Rate(intervalVar).TopK(10),
+				"rx-drop-{{ device }}"),
+			t.track("nodeNetworkTxDrop",
+				mg.Raw("node_network_transmit_drop_total{"+instanceFilter+"}").
+					Rate(intervalVar).TopK(10),
+				"tx-drop-{{ device }}"),
 		)).
-		WithPanel(genericLegendCounterTimeSeries("Conntrack stats: $_worker_node", "",
+		WithPanel(genericLegendCounterTimeSeries("Conntrack stats: $"+nodeVar, "",
 			12, 8,
-			promQuery(`node_nf_conntrack_entries{instance=~"$_worker_node"}`, "conntrack_entries"),
-			promQuery(`node_nf_conntrack_entries_limit{instance=~"$_worker_node"}`, "conntrack_limit"),
+			t.track("nodeConntrackEntries", mg.Q(mg.MetricNodeNFConntrackEntries, instanceFilter), "conntrack_entries"),
+			t.track("nodeConntrackLimit", mg.Q(mg.MetricNodeNFConntrackEntriesLimit, instanceFilter), "conntrack_limit"),
 		)).
-		WithPanel(genericLegendTimeSeries("Top 10 container CPU: $_worker_node", "percent",
+		WithPanel(genericLegendTimeSeries("Top 10 container CPU: $"+nodeVar, "percent",
 			12, 8,
-			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container!="POD",name!="",node=~"$_worker_node",namespace!="",namespace=~"$namespace"}[$interval])) by (pod,container,namespace,name,service) * 100)`, "{{ pod }}: {{ container }}"),
-			promQuery(`topk(10, container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{node=~"$_worker_node",namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
+			promQuery(
+				mg.Q(mg.MetricContainerCPU, `container!="POD",name!="",`+nodeFilter+`,namespace!="",namespace=~"$namespace"`).
+					IRate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByPod, mg.GroupByContainer, mg.GroupByNamespace, mg.GroupByName, "service").
+					Multiply("100").
+					TopK(10).String(),
+				"{{ pod }}: {{ container }}"),
+			promQuery(`topk(10, container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{`+nodeFilter+`,namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
 		)).
-		WithPanel(genericLegendCounterTimeSeries("Top 10 container RSS: $_worker_node", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("Top 10 container RSS: $"+nodeVar, "bytes",
 			12, 8,
-			promQuery(`topk(10, container_memory_rss{container!="POD",name!="",node=~"$_worker_node",namespace!="",namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
-			promQuery(`topk(10, container_memory_working_set_bytes_container{node=~"$_worker_node",namespace=~"$namespace"})`, "{{pod}} - {{node}}"),
-		)).
-		WithPanel(genericLegendTimeSeries("cgroup CPU: $_worker_node", "percent",
-			12, 8,
-			promQuery(`sum by (id) ( rate(container_cpu_usage_seconds_total{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/.*/ovsdb-server.service|/system.slice/systemd-udevd.service|/kubepods.slice", node=~"$_worker_node"}[$interval])) * 100`, "{{ id }}"),
-			promQuery(`container_cpu_usage_seconds_total_cgroup_sum_rate_id_node{node=~"$_worker_node"}`, "{{ id }}"),
-		)).
-		WithPanel(genericLegendCounterTimeSeries("cgroup RSS: $_worker_node", "bytes",
-			12, 8,
-			promQuery(`sum by (id) ( container_memory_rss{ job=~".*", id =~"/system.slice|/system.slice/kubelet.service|/.*/ovs-vswitchd.service|/system.slice/crio.service|/system.slice/systemd-journald.service|/system.slice/.*.service|/system.slice/systemd-udevd.service|/kubepods.slice", node=~"$_worker_node"})`, "{{ id }}"),
-			promQuery(`container_memory_working_set_bytes_cgroup{node=~"$_worker_node"}`, "{{ id }}"),
+			promQuery(
+				mg.Q(mg.MetricContainerMemoryRSS, `container!="POD",name!="",`+nodeFilter+`,namespace!="",namespace=~"$namespace"`).
+					TopK(10).String(),
+				"{{ pod }}: {{ container }}"),
+			promQuery(`topk(10, container_memory_working_set_bytes_container{`+nodeFilter+`,namespace=~"$namespace"})`, "{{pod}} - {{node}}"),
 		))
-}
 
-// Row: Infra (repeats on _infra_node)
-func ocpInfraRow() *dashboard.RowBuilder {
-	return dashboard.NewRowBuilder("Infra: $_infra_node").
-		Collapsed(true).
-		Repeat("_infra_node").
-		WithPanel(genericLegendTimeSeries("CPU Basic: $_infra_node", "percent",
+	row = row.
+		WithPanel(genericLegendTimeSeries("cgroup CPU: $"+nodeVar, "percent",
 			12, 8,
-			promQuery(`sum by (instance, mode)(irate(node_cpu_seconds_total{instance=~"$_infra_node",job=~".*"}[$interval])) * 100`, "Busy {{mode}}"),
-			promQuery(`node_cpu_seconds_sum_rate_2m_30s_instance_mode_node_panel{instance=~"$_infra_node",job=~".*"}`, "Busy {{mode}}"),
+			t.track("cgroupCPU",
+				mg.Q(mg.MetricContainerCPU, cgroupIDFilter+", "+nodeFilter).
+					Rate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByID).
+					Multiply("100"),
+				"{{ id }}"),
+			promQuery(`container_cpu_usage_seconds_total_cgroup_sum_rate_id_node{`+nodeFilter+`}`, "{{ id }}"),
 		)).
-		WithPanel(genericLegendTimeSeries("System Memory: $_infra_node", "bytes",
+		WithPanel(genericLegendCounterTimeSeries("cgroup RSS: $"+nodeVar, "bytes",
 			12, 8,
-			promQuery(`node_memory_Active_bytes{instance=~"$_infra_node"}`, "Active"),
-			promQuery(`node_memory_MemTotal_bytes{instance=~"$_infra_node"}`, "Total"),
-			promQuery(`node_memory_Cached_bytes{instance=~"$_infra_node"} + node_memory_Buffers_bytes{instance=~"$_infra_node"}`, "Cached + Buffers"),
-			promQuery(`node_memory_MemAvailable_bytes{instance=~"$_infra_node"}`, "Available"),
-			promQuery(`(node_memory_MemTotal_bytes{instance=~"$_infra_node"} - (node_memory_MemFree_bytes{instance=~"$_infra_node"} + node_memory_Buffers_bytes{instance=~"$_infra_node"} +  node_memory_Cached_bytes{instance=~"$_infra_node"}))`, "Used"),
+			t.track("cgroupRSS",
+				mg.Q(mg.MetricContainerMemoryRSS, cgroupIDFilterWithJournald+", "+nodeFilter).
+					Agg(mg.AggSum, mg.GroupByID),
+				"{{ id }}"),
+			promQuery(`container_memory_working_set_bytes_cgroup{`+nodeFilter+`}`, "{{ id }}"),
 		)).
-		WithPanel(genericLegendTimeSeries("Disk throughput: $_infra_node", "Bps",
+		WithPanel(genericLegendTimeSeries("Pod fs rw rate: $"+nodeVar, "Bps",
 			12, 8,
-			promQuery(`rate(node_disk_read_bytes_total{device=~"$block_device",instance=~"$_infra_node"}[$interval])`, "{{ device }} - read"),
-			promQuery(`rate(node_disk_written_bytes_total{device=~"$block_device",instance=~"$_infra_node"}[$interval])`, "{{ device }} - write"),
+			t.track("podFSWrites",
+				mg.Q(mg.MetricContainerFSWrites, fsWriteFilter+", "+nodeFilter+`, pod!=""`).
+					Rate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByDevice, mg.GroupByPod),
+				"{{ pod }}: {{ device }} - write"),
+			promQuery(`container_fs_writes_bytes_total_container_sum_rate_pod_node_device{`+nodeFilter+`}`, "{{ pod }}: {{ device }} - write"),
+			t.track("podFSReads",
+				mg.Raw(`container_fs_reads_bytes_total{`+fsReadFilter+", "+nodeFilter+`, pod!=""}`).
+					Rate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByDevice, mg.GroupByPod),
+				"{{ pod }}: {{ device }} - read"),
+			promQuery(`container_fs_reads_bytes_total_container_sum_rate_pod_node_device{`+nodeFilter+`}`, "{{ pod }}: {{ device }} - read"),
 		)).
-		WithPanel(genericLegendTimeSeries("Disk IOPS: $_infra_node", "iops",
+		WithPanel(genericLegendTimeSeries("cgroup fs rw rate: $"+nodeVar, "Bps",
 			12, 8,
-			promQuery(`rate(node_disk_reads_completed_total{device=~"$block_device",instance=~"$_infra_node"}[$interval])`, "{{ device }} - read"),
-			promQuery(`rate(node_disk_writes_completed_total{device=~"$block_device",instance=~"$_infra_node"}[$interval])`, "{{ device }} - write"),
-		)).
-		WithPanel(genericLegendTimeSeries("Network Utilization: $_infra_node", "bps",
-			12, 8,
-			promQuery(`rate(node_network_receive_bytes_total{instance=~"$_infra_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - RX"),
-			promQuery(`rate(node_network_transmit_bytes_total{instance=~"$_infra_node",device=~"$net_device"}[$interval]) * 8`, "{{instance}} - {{device}} - TX"),
-		)).
-		WithPanel(genericLegendTimeSeries("Network Packets: $_infra_node", "pps",
-			12, 8,
-			promQuery(`rate(node_network_receive_packets_total{instance=~"$_infra_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - RX"),
-			promQuery(`rate(node_network_transmit_packets_total{instance=~"$_infra_node",device=~"$net_device"}[$interval])`, "{{instance}} - {{device}} - TX"),
-		)).
-		WithPanel(genericLegendTimeSeries("Network packets drop: $_infra_node", "pps",
-			12, 8,
-			promQuery(`topk(10, rate(node_network_receive_drop_total{instance=~"$_infra_node"}[$interval]))`, "rx-drop-{{ device }}"),
-			promQuery(`topk(10,rate(node_network_transmit_drop_total{instance=~"$_infra_node"}[$interval]))`, "tx-drop-{{ device }}"),
-		)).
-		WithPanel(genericLegendTimeSeries("Conntrack stats: $_infra_node", "",
-			12, 8,
-			promQuery(`node_nf_conntrack_entries{instance=~"$_infra_node"}`, "conntrack_entries"),
-			promQuery(`node_nf_conntrack_entries_limit{instance=~"$_infra_node"}`, "conntrack_limit"),
-		)).
-		WithPanel(genericLegendTimeSeries("Top 10 container CPU: $_infra_node", "percent",
-			12, 8,
-			promQuery(`topk(10, sum(irate(container_cpu_usage_seconds_total{container!="POD",name!="",node=~"$_infra_node",namespace!="",namespace=~"$namespace"}[$interval])) by (pod,container,namespace,name,service) * 100)`, "{{ pod }}: {{ container }}"),
-			promQuery(`topk(10, container_cpu_usage_seconds_total_container_sum_rate_pod_node_container_namespace_name{node=~"$_infra_node",namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
-		)).
-		WithPanel(genericLegendTimeSeries("Top 10 container RSS: $_infra_node", "bytes",
-			12, 8,
-			promQuery(`topk(10, container_memory_rss{container!="POD",name!="",node=~"$_infra_node",namespace!="",namespace=~"$namespace"})`, "{{ pod }}: {{ container }}"),
-			promQuery(`topk(10, container_memory_working_set_bytes_container{node=~"$_infra_node",namespace=~"$namespace"})`, "{{pod}} - {{node}}"),
+			t.track("cgroupFSWrites",
+				mg.Q(mg.MetricContainerFSWrites, cgroupFSIDFilter+", "+nodeFilter).
+					Rate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByDevice, mg.GroupByID),
+				"{{ id }}: {{ device }} - write"),
+			promQuery(`container_fs_writes_bytes_total_cgroup_sum_rate_id_node_device{`+nodeFilter+`}`, "{{ id }}: {{ device }} - write"),
+			t.track("cgroupFSReads",
+				mg.Raw(`container_fs_reads_bytes_total{`+cgroupFSIDFilter+", "+nodeFilter+`}`).
+					Rate(intervalVar).
+					Agg(mg.AggSum, mg.GroupByDevice, mg.GroupByID),
+				"{{ id }}: {{ device }} - read"),
+			promQuery(`container_fs_reads_bytes_total_cgroup_sum_rate_id_node_device{`+nodeFilter+`}`, "{{ id }}: {{ device }} - read"),
 		))
+
+	return row
 }

--- a/go/panel_tracker.go
+++ b/go/panel_tracker.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
+	mg "github.com/afcollins/metrics-generator/pkg/metrics"
+)
+
+// panelTracker is implemented by any type that registers panel queries and returns panel targets.
+// Row builder functions accept panelTracker so tracker implementations can be swapped
+// without changing call sites.
+type panelTracker interface {
+	track(name string, query *mg.Query, legend string) *prometheus.DataqueryBuilder
+	trackRaw(name string, expr string, legend string) *prometheus.DataqueryBuilder
+	trackVarQuery(expr string) dashboard.StringOrMap
+}
+
+// namedProfile pairs a filename suffix with a populated Generator.
+type namedProfile struct {
+	suffix string
+	g      *mg.Generator
+}

--- a/go/panel_tracker.go
+++ b/go/panel_tracker.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	mg "github.com/afcollins/metrics-generator/pkg/metrics"
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
 	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
-	mg "github.com/afcollins/metrics-generator/pkg/metrics"
 )
 
 // panelTracker is implemented by any type that registers panel queries and returns panel targets.

--- a/go/query_tracker.go
+++ b/go/query_tracker.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
+	mg "github.com/afcollins/metrics-generator/pkg/metrics"
+)
+
+// profileInterval is substituted for $interval in metrics profile queries.
+const profileInterval = mg.Rate2m
+
+var grafanaVarRe = regexp.MustCompile(`,?\s*\w+[=!~]+=?"[^"]*\$[^"]*"`)
+
+func stripGrafanaVars(expr string) string {
+	clean := grafanaVarRe.ReplaceAllString(expr, "")
+	clean = strings.ReplaceAll(clean, "{}", "")
+	clean = strings.ReplaceAll(clean, "$interval", string(profileInterval))
+	return clean
+}
+
+// queryTracker implements panelTracker. Registers aggregated PromQL queries in a Generator.
+// When useMetricNames is true, panel targets use the registered metric name as the query
+// expression — for dashboards that visualize already-collected metrics.
+type queryTracker struct {
+	g              *mg.Generator
+	useMetricNames bool
+	seen           map[string]struct{} // dedup by stripped query; prevents role-variant tripling
+}
+
+func (t *queryTracker) add(name, stripped string) {
+	if t.g == nil {
+		return
+	}
+	if t.seen == nil {
+		t.seen = map[string]struct{}{}
+	}
+	if _, dup := t.seen[stripped]; dup {
+		return
+	}
+	t.seen[stripped] = struct{}{}
+	t.g.Add(name, stripped)
+}
+
+func (t *queryTracker) track(name string, query *mg.Query, legend string) *prometheus.DataqueryBuilder {
+	t.add(name, stripGrafanaVars(query.String()))
+	if t.useMetricNames {
+		return promQuery(name, legend)
+	}
+	return promQuery(query.String(), legend)
+}
+
+func (t *queryTracker) trackVarQuery(expr string) dashboard.StringOrMap {
+	return dashboard.StringOrMap{String: cog.ToPtr(expr)}
+}
+
+func (t *queryTracker) trackRaw(name string, expr string, legend string) *prometheus.DataqueryBuilder {
+	t.add(name, stripGrafanaVars(expr))
+	if t.useMetricNames {
+		return promQuery(name, legend)
+	}
+	return promQuery(expr, legend)
+}

--- a/go/query_tracker.go
+++ b/go/query_tracker.go
@@ -4,10 +4,10 @@ import (
 	"regexp"
 	"strings"
 
+	mg "github.com/afcollins/metrics-generator/pkg/metrics"
 	"github.com/grafana/grafana-foundation-sdk/go/cog"
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
 	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
-	mg "github.com/afcollins/metrics-generator/pkg/metrics"
 )
 
 // profileInterval is substituted for $interval in metrics profile queries.

--- a/go/raw_tracker.go
+++ b/go/raw_tracker.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"regexp"
+
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
+	mg "github.com/afcollins/metrics-generator/pkg/metrics"
+)
+
+var (
+	stringLiteralRe = regexp.MustCompile(`"[^"]*"`)
+	labelSelectorRe = regexp.MustCompile(`\{[^}]*\}`)
+	rateDurationRe  = regexp.MustCompile(`\[[^\]]*\]`)
+	// strips by(...), without(...), on(...), ignoring(...), group_left(...), group_right(...)
+	groupClauseRe = regexp.MustCompile(`\b(?:by|without|on|ignoring|group_left|group_right)\s*\([^)]*\)`)
+)
+
+// promFunctions is the deny-list of PromQL function names and keywords that share the
+// [a-z][a-z0-9_]* pattern with Prometheus metric names.
+var promFunctions = map[string]struct{}{
+	"rate": {}, "irate": {}, "increase": {}, "delta": {}, "idelta": {},
+	"sum": {}, "avg": {}, "max": {}, "min": {}, "count": {}, "stddev": {}, "stdvar": {},
+	"topk": {}, "bottomk": {}, "count_values": {}, "quantile": {},
+	"histogram_quantile": {}, "histogram_sum": {}, "histogram_count": {},
+	"label_replace": {}, "label_join": {}, "label_values": {},
+	"vector": {}, "scalar": {}, "absent": {}, "absent_over_time": {},
+	"changes": {}, "resets": {}, "deriv": {}, "predict_linear": {},
+	"time": {}, "timestamp": {},
+	"day_of_month": {}, "day_of_week": {}, "days_in_month": {},
+	"hour": {}, "minute": {}, "month": {}, "year": {},
+	"floor": {}, "ceil": {}, "round": {}, "clamp": {}, "clamp_min": {}, "clamp_max": {},
+	"exp": {}, "ln": {}, "log2": {}, "log10": {}, "sqrt": {}, "abs": {}, "sgn": {},
+	"sort": {}, "sort_desc": {},
+	"avg_over_time": {}, "min_over_time": {}, "max_over_time": {}, "sum_over_time": {},
+	"count_over_time": {}, "stdvar_over_time": {}, "stddev_over_time": {},
+	"last_over_time": {}, "present_over_time": {}, "quantile_over_time": {},
+	"by": {}, "without": {}, "on": {}, "ignoring": {},
+	"group_left": {}, "group_right": {}, "bool": {}, "offset": {},
+	"and": {}, "or": {}, "unless": {}, "inf": {}, "nan": {},
+}
+
+// knownLabels is a deny-list of common Prometheus label names that are never
+// metric names. Used to suppress false positives from label_values(metric, label).
+var knownLabels = map[string]struct{}{
+	"pod": {}, "node": {}, "device": {}, "namespace": {},
+	"instance": {}, "le": {}, "alertname": {}, "severity": {},
+}
+
+var identRe = regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9_]*`)
+
+// extractRawMetrics returns all unique raw Prometheus metric names in expr,
+// excluding PromQL function names, keywords, and known label names.
+func extractRawMetrics(expr string) []string {
+	clean := stripGrafanaVars(expr)
+	clean = stringLiteralRe.ReplaceAllString(clean, "")
+	clean = labelSelectorRe.ReplaceAllString(clean, "")
+	clean = rateDurationRe.ReplaceAllString(clean, "")
+	clean = groupClauseRe.ReplaceAllString(clean, "")
+
+	seen := map[string]struct{}{}
+	var out []string
+	for _, name := range identRe.FindAllString(clean, -1) {
+		if _, isFunc := promFunctions[name]; isFunc {
+			continue
+		}
+		if _, isLabel := knownLabels[name]; isLabel {
+			continue
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}
+
+// rawTracker implements panelTracker. Extracts raw Prometheus metric names from every
+// tracked expression and registers them 1:1 in a Generator.
+type rawTracker struct {
+	g    *mg.Generator
+	seen map[string]struct{}
+}
+
+func (t *rawTracker) track(_ string, query *mg.Query, legend string) *prometheus.DataqueryBuilder {
+	t.register(query.String())
+	return promQuery(query.String(), legend)
+}
+
+func (t *rawTracker) trackRaw(_ string, expr string, legend string) *prometheus.DataqueryBuilder {
+	t.register(expr)
+	return promQuery(expr, legend)
+}
+
+func (t *rawTracker) trackVarQuery(expr string) dashboard.StringOrMap {
+	t.register(expr)
+	return dashboard.StringOrMap{String: cog.ToPtr(expr)}
+}
+
+func (t *rawTracker) register(expr string) {
+	for _, name := range extractRawMetrics(expr) {
+		if _, seen := t.seen[name]; seen {
+			continue
+		}
+		t.seen[name] = struct{}{}
+		t.g.Add(name, name)
+	}
+}

--- a/go/raw_tracker.go
+++ b/go/raw_tracker.go
@@ -3,10 +3,10 @@ package main
 import (
 	"regexp"
 
+	mg "github.com/afcollins/metrics-generator/pkg/metrics"
 	"github.com/grafana/grafana-foundation-sdk/go/cog"
 	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
 	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
-	mg "github.com/afcollins/metrics-generator/pkg/metrics"
 )
 
 var (

--- a/go/tracker_test.go
+++ b/go/tracker_test.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"regexp"
+	"testing"
+
+	mg "github.com/afcollins/metrics-generator/pkg/metrics"
+	"gopkg.in/yaml.v3"
+)
+
+type metricDef struct {
+	MetricName string `yaml:"metricName"`
+	Query      string `yaml:"query"`
+}
+
+func parseProfile(t *testing.T, g *mg.Generator) []metricDef {
+	t.Helper()
+	b, err := g.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	var defs []metricDef
+	if err := yaml.Unmarshal(b, &defs); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	return defs
+}
+
+// ---------------------------------------------------------------------------
+// extractRawMetrics unit tests
+// ---------------------------------------------------------------------------
+
+func TestExtractRawMetrics(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+		want []string
+		bad  []string
+	}{
+		{
+			name: "simple metric",
+			expr: `container_cpu_usage_seconds_total{}`,
+			want: []string{"container_cpu_usage_seconds_total"},
+		},
+		{
+			name: "rate expression with grafana interval",
+			expr: `rate(container_cpu_usage_seconds_total{namespace=~"$Namespace"}[$interval])`,
+			want: []string{"container_cpu_usage_seconds_total"},
+			bad:  []string{"interval", "namespace", "Namespace"},
+		},
+		{
+			name: "string literal with hyphen does not split",
+			expr: `kube_pod_info{namespace="openshift-monitoring"}`,
+			want: []string{"kube_pod_info"},
+			bad:  []string{"openshift", "monitoring"},
+		},
+		{
+			name: "camelCase metric name",
+			expr: `node_memory_MemAvailable_bytes{}`,
+			want: []string{"node_memory_MemAvailable_bytes"},
+			bad:  []string{"em", "vailable_bytes", "MemAvailable"},
+		},
+		{
+			name: "binary expression with by clause",
+			expr: `sum(node_cpu_seconds_total{}) by (namespace, node, instance)`,
+			want: []string{"node_cpu_seconds_total"},
+			bad:  []string{"namespace", "node", "instance"},
+		},
+		{
+			name: "group_left join does not leak label names",
+			expr: `kube_pod_info{} * on (pod) group_left(node) kube_node_role{}`,
+			want: []string{"kube_pod_info", "kube_node_role"},
+			bad:  []string{"pod", "node", "on"},
+		},
+		{
+			name: "promql functions excluded",
+			expr: `histogram_quantile(0.99, sum(rate(ovnkube_controller_pod_creation_latency_seconds_bucket{}[2m])) by (le))`,
+			want: []string{"ovnkube_controller_pod_creation_latency_seconds_bucket"},
+			bad:  []string{"histogram_quantile", "sum", "rate", "by", "le"},
+		},
+		{
+			name: "uppercase metric name ALERTS",
+			expr: `topk(10,sum(ALERTS{severity!="none"}) by (alertname, severity))`,
+			want: []string{"ALERTS"},
+			bad:  []string{"alertname", "severity", "topk", "sum", "by"},
+		},
+		{
+			name: "label_values extracts metric not label arg",
+			expr: `label_values(etcd_cluster_version, pod)`,
+			want: []string{"etcd_cluster_version"},
+			bad:  []string{"label_values", "pod"},
+		},
+		{
+			name: "label_values with label selector strips label name arg",
+			expr: `label_values(kube_node_role{role="master"}, node)`,
+			want: []string{"kube_node_role"},
+			bad:  []string{"label_values", "node", "role"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractRawMetrics(tc.expr)
+			gotSet := make(map[string]bool, len(got))
+			for _, m := range got {
+				gotSet[m] = true
+			}
+			for _, w := range tc.want {
+				if !gotSet[w] {
+					t.Errorf("want %q in result, got %v", w, got)
+				}
+			}
+			for _, b := range tc.bad {
+				if gotSet[b] {
+					t.Errorf("unwanted %q found in result %v", b, got)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// rawTracker integration tests
+// ---------------------------------------------------------------------------
+
+func TestRawTrackerOCPDashboard(t *testing.T) {
+	g := &mg.Generator{}
+	buildOCPDashboard(&rawTracker{g: g, seen: map[string]struct{}{}})
+	defs := parseProfile(t, g)
+
+	if len(defs) == 0 {
+		t.Fatal("rawTracker produced no metrics")
+	}
+
+	byName := make(map[string]metricDef, len(defs))
+	for _, d := range defs {
+		byName[d.MetricName] = d
+	}
+
+	// Known real metrics must be present.
+	mustHave := []string{
+		"container_cpu_usage_seconds_total",
+		"container_memory_rss",
+		"node_memory_MemAvailable_bytes",
+		"node_cpu_seconds_total",
+		"kube_node_status_condition",
+		"kube_pod_status_phase",
+	}
+	for _, m := range mustHave {
+		if _, ok := byName[m]; !ok {
+			t.Errorf("expected metric %q missing from raw profile", m)
+		}
+	}
+
+	// Known garbage tokens must not appear.
+	mustNotHave := []string{
+		"namespace", "container", "node", "pod", "instance", "le",
+		"interval", "em", "vailable_bytes", "eady", "ending",
+		"openshift", "monitoring",
+	}
+	for _, bad := range mustNotHave {
+		if _, ok := byName[bad]; ok {
+			t.Errorf("garbage token %q found in raw profile", bad)
+		}
+	}
+
+	// Every metric name and query must be 1:1 (rawTracker registers metric as its own query).
+	for _, d := range defs {
+		if d.MetricName != d.Query {
+			t.Errorf("rawTracker entry not 1:1: metricName=%q query=%q", d.MetricName, d.Query)
+		}
+	}
+}
+
+func TestRawTrackerNoDuplicates(t *testing.T) {
+	g := &mg.Generator{}
+	buildOCPDashboard(&rawTracker{g: g, seen: map[string]struct{}{}})
+	defs := parseProfile(t, g)
+
+	seen := map[string]int{}
+	for _, d := range defs {
+		seen[d.MetricName]++
+	}
+	for name, count := range seen {
+		if count > 1 {
+			t.Errorf("metric %q appears %d times in raw profile (want 1)", name, count)
+		}
+	}
+}
+
+func TestOCPDashboardNoStaleDeclarations(t *testing.T) {
+	g := &mg.Generator{}
+	buildOCPDashboard(&rawTracker{g: g, seen: map[string]struct{}{}})
+	defs := parseProfile(t, g)
+
+	inProfile := make(map[string]struct{}, len(defs))
+	for _, d := range defs {
+		inProfile[d.MetricName] = struct{}{}
+	}
+
+	var missing []string
+	for _, metric := range ocpDashboardMetrics {
+		if _, ok := inProfile[string(metric)]; !ok {
+			missing = append(missing, string(metric))
+		}
+	}
+	for _, m := range missing {
+		t.Errorf("metric %q declared in ocpDashboardMetrics but not found in any panel query", m)
+	}
+}
+
+// grafanaVarInQuery matches $VarName (Grafana template variables) but not $1/$2 (regex back-refs).
+var grafanaVarInQuery = regexp.MustCompile(`\$[a-zA-Z_]`)
+
+// ---------------------------------------------------------------------------
+// queryTracker integration tests
+// ---------------------------------------------------------------------------
+
+func TestQueryTrackerNoGrafanaVars(t *testing.T) {
+	g := &mg.Generator{}
+	buildOCPDashboard(&queryTracker{g: g})
+	defs := parseProfile(t, g)
+
+	if len(defs) == 0 {
+		t.Fatal("queryTracker produced no metrics")
+	}
+
+	for _, d := range defs {
+		if grafanaVarInQuery.MatchString(d.Query) {
+			t.Errorf("Grafana variable in query for %q: %s", d.MetricName, d.Query)
+		}
+	}
+}
+
+func TestRawTrackerEtcdVariableQueryMetrics(t *testing.T) {
+	g := &mg.Generator{}
+	buildEtcdDash(&rawTracker{g: g, seen: map[string]struct{}{}})
+	defs := parseProfile(t, g)
+
+	byName := make(map[string]metricDef, len(defs))
+	for _, d := range defs {
+		byName[d.MetricName] = d
+	}
+
+	// etcd_cluster_version is only in the variable query, not any panel.
+	if _, ok := byName["etcd_cluster_version"]; !ok {
+		t.Error("etcd_cluster_version missing from raw profile (only in variable query)")
+	}
+
+	// Known label names must not appear as metric entries.
+	for _, bad := range []string{"pod", "label_values"} {
+		if _, ok := byName[bad]; ok {
+			t.Errorf("garbage token %q found in etcd raw profile", bad)
+		}
+	}
+}
+
+func TestQueryTrackerNoDuplicates(t *testing.T) {
+	g := &mg.Generator{}
+	buildOCPDashboard(&queryTracker{g: g})
+	defs := parseProfile(t, g)
+
+	seen := map[string]int{}
+	for _, d := range defs {
+		seen[d.MetricName]++
+	}
+	for name, count := range seen {
+		if count > 1 {
+			t.Errorf("metric %q appears %d times in aggregated profile (want 1)", name, count)
+		}
+	}
+}

--- a/go/tracker_test.go
+++ b/go/tracker_test.go
@@ -15,10 +15,7 @@ type metricDef struct {
 
 func parseProfile(t *testing.T, g *mg.Generator) []metricDef {
 	t.Helper()
-	b, err := g.Generate()
-	if err != nil {
-		t.Fatalf("Generate: %v", err)
-	}
+	b := g.Generate()
 	var defs []metricDef
 	if err := yaml.Unmarshal(b, &defs); err != nil {
 		t.Fatalf("yaml.Unmarshal: %v", err)


### PR DESCRIPTION
## Type of change

- [X] Refactor

## Description

Introduces a framework to programmatically build prometheus queries.

Also introduces a query tracker that allows for
* easy extraction of all source metrics,
* generation of metrics profiles to collect data to reproduce the dashboards, and
* generation of dashboards using source or recorded metrics

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
```
cd go
go run .
# Import the rendered ocp-performance.json dashboard into grafana and browse data
```